### PR TITLE
🧹 [code health improvement] Remove dead code allow in Context

### DIFF
--- a/src/type_checker/context.rs
+++ b/src/type_checker/context.rs
@@ -89,14 +89,12 @@ pub struct EnumDefinition {
     // Use BTreeMap for deterministic variant order (crucial for discriminants)
     pub variants: BTreeMap<String, Vec<Type>>,
     pub generics: Option<Vec<GenericDefinition>>,
-    #[allow(dead_code)]
     pub module: String,
 }
 
 /// Definition of a generic type parameter.
 #[derive(Debug, Clone)]
 pub struct GenericDefinition {
-    #[allow(dead_code)]
     pub name: String,
     pub constraint: Option<Type>,
     pub kind: TypeDeclarationKind,


### PR DESCRIPTION
The `#[allow(dead_code)]` attribute was removed from `GenericDefinition::name` and `EnumDefinition::module` in `src/type_checker/context.rs` to improve code health. These fields are confirmed to be used in several locations within the codebase, making the attributes unnecessary. This change cleans up the metadata and removes stale lint suppressions without affecting program logic.

---
*PR created automatically by Jules for task [14604258550887904896](https://jules.google.com/task/14604258550887904896) started by @slavikdev*