### PR TITLE
🧪 [testing improvement] Add unit tests for find_best_match in tests/ directory

### DIFF
--- a/tests/error/formatting_unit.rs
+++ b/tests/error/formatting_unit.rs
@@ -51,3 +51,59 @@ fn test_format_diagnostic_full_warning() {
         "Output should contain 'warning'"
     );
 }
+
+#[test]
+fn test_levenshtein_distance() {
+    use miri::error::format::levenshtein_distance;
+    assert_eq!(levenshtein_distance("", ""), 0);
+    assert_eq!(levenshtein_distance("abc", "abc"), 0);
+    assert_eq!(levenshtein_distance("abc", ""), 3);
+    assert_eq!(levenshtein_distance("", "abc"), 3);
+    assert_eq!(levenshtein_distance("kitten", "sitting"), 3);
+    assert_eq!(levenshtein_distance("flaw", "lawn"), 2);
+    assert_eq!(levenshtein_distance("saturday", "sunday"), 3);
+    assert_eq!(levenshtein_distance("rust", "rustacean"), 5);
+}
+
+#[test]
+fn test_find_best_match_exact() {
+    use miri::error::format::find_best_match;
+    let candidates = vec!["apple", "banana", "cherry"];
+    assert_eq!(find_best_match("apple", &candidates), Some("apple".to_string()));
+}
+
+#[test]
+fn test_find_best_match_close() {
+    use miri::error::format::find_best_match;
+    let candidates = vec!["apple", "banana", "cherry"];
+    assert_eq!(find_best_match("appl", &candidates), Some("apple".to_string()));
+}
+
+#[test]
+fn test_find_best_match_threshold() {
+    use miri::error::format::find_best_match;
+    let candidates = vec!["apple", "banana", "cherry"];
+    assert_eq!(find_best_match("abc", &candidates), None);
+}
+
+#[test]
+fn test_find_best_match_empty_candidates() {
+    use miri::error::format::find_best_match;
+    let candidates: Vec<&str> = vec![];
+    assert_eq!(find_best_match("apple", &candidates), None);
+}
+
+#[test]
+fn test_find_best_match_best_of_multiple() {
+    use miri::error::format::find_best_match;
+    let candidates = vec!["apple", "apply", "app"];
+    assert_eq!(find_best_match("appl", &candidates), Some("apple".to_string()));
+}
+
+#[test]
+fn test_find_best_match_unicode() {
+    use miri::error::format::find_best_match;
+    let candidates = vec!["🦀rust", "🚀fast"];
+    assert_eq!(find_best_match("🦀rust", &candidates), Some("🦀rust".to_string()));
+    assert_eq!(find_best_match("🦀rus", &candidates), Some("🦀rust".to_string()));
+}

--- a/tests/error/formatting_unit.rs
+++ b/tests/error/formatting_unit.rs
@@ -69,14 +69,20 @@ fn test_levenshtein_distance() {
 fn test_find_best_match_exact() {
     use miri::error::format::find_best_match;
     let candidates = vec!["apple", "banana", "cherry"];
-    assert_eq!(find_best_match("apple", &candidates), Some("apple".to_string()));
+    assert_eq!(
+        find_best_match("apple", &candidates),
+        Some("apple".to_string())
+    );
 }
 
 #[test]
 fn test_find_best_match_close() {
     use miri::error::format::find_best_match;
     let candidates = vec!["apple", "banana", "cherry"];
-    assert_eq!(find_best_match("appl", &candidates), Some("apple".to_string()));
+    assert_eq!(
+        find_best_match("appl", &candidates),
+        Some("apple".to_string())
+    );
 }
 
 #[test]
@@ -97,13 +103,22 @@ fn test_find_best_match_empty_candidates() {
 fn test_find_best_match_best_of_multiple() {
     use miri::error::format::find_best_match;
     let candidates = vec!["apple", "apply", "app"];
-    assert_eq!(find_best_match("appl", &candidates), Some("apple".to_string()));
+    assert_eq!(
+        find_best_match("appl", &candidates),
+        Some("apple".to_string())
+    );
 }
 
 #[test]
 fn test_find_best_match_unicode() {
     use miri::error::format::find_best_match;
     let candidates = vec!["🦀rust", "🚀fast"];
-    assert_eq!(find_best_match("🦀rust", &candidates), Some("🦀rust".to_string()));
-    assert_eq!(find_best_match("🦀rus", &candidates), Some("🦀rust".to_string()));
+    assert_eq!(
+        find_best_match("🦀rust", &candidates),
+        Some("🦀rust".to_string())
+    );
+    assert_eq!(
+        find_best_match("🦀rus", &candidates),
+        Some("🦀rust".to_string())
+    );
 }


### PR DESCRIPTION
This PR adds unit tests for the `find_best_match` and `levenshtein_distance` functions, located in `tests/error/formatting_unit.rs`. These functions are used for providing helpful suggestions in diagnostic messages.

The tests cover various scenarios, including exact matches, fuzzy matches within the similarity threshold, and handling of Unicode characters. Placing the tests in the `tests/` directory follows the user's preference for test organization and verifies the public API of the `error::format` module.

---
*PR created automatically by Jules for task [7164288001527766033](https://jules.google.com/task/7164288001527766033) started by @slavikdev*