### PR TITLE
🔒 security: fix insecure build output directory creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ logos = "0.16.0"
 rustyline = "17.0.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+tempfile = "3.24.0"
 thiserror = "2.0.17"
 walkdir = "2.5.0"
 
@@ -44,5 +45,3 @@ inkwell = { version = "0.7.1", features = ["llvm21-1"], optional = true }
 assert_cmd = "2.0"
 predicates = "3.1.3"
 regex = "1.12.2"
-tempfile = "3.24.0"
-

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -300,10 +300,9 @@ impl Pipeline {
 
     /// Compile and execute the source, returning the process exit code.
     pub fn run(&self, source: &str) -> Result<i32, CompilerError> {
-        let temp_dir = std::env::temp_dir().join(format!("miri_run_{}", std::process::id()));
-        fs::create_dir_all(&temp_dir)?;
-
-        let executable_path = temp_dir.join("program");
+        let temp_dir = tempfile::tempdir()
+            .map_err(|e| CompilerError::Codegen(format!("Failed to create temp dir: {}", e)))?;
+        let executable_path = temp_dir.path().join("program");
 
         let build_opts = BuildOptions {
             out_path: Some(executable_path.clone()),
@@ -392,16 +391,13 @@ impl Pipeline {
                 .unwrap_or_else(|| PathBuf::from("."));
             (work_dir, out)
         } else {
-            use std::time::{SystemTime, UNIX_EPOCH};
-            let timestamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
-            let unique_dir = std::env::temp_dir().join("miri_build").join(format!(
-                "{}_{}",
-                timestamp,
-                std::process::id()
-            ));
+            let unique_dir = tempfile::Builder::new()
+                .prefix("miri_build_")
+                .tempdir()
+                .map_err(|e| {
+                    CompilerError::Codegen(format!("Failed to create build directory: {}", e))
+                })?
+                .into_path();
             let out = unique_dir.join("a.out");
             (unique_dir, out)
         };

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -396,8 +396,9 @@ impl Pipeline {
                 .tempdir()
                 .map_err(|e| {
                     CompilerError::Codegen(format!("Failed to create build directory: {}", e))
-                })?
-                .into_path();
+                })?;
+            #[allow(deprecated)]
+            let unique_dir = unique_dir.into_path();
             let out = unique_dir.join("a.out");
             (unique_dir, out)
         };

--- a/test_tempfile.rs
+++ b/test_tempfile.rs
@@ -1,0 +1,6 @@
+use tempfile::tempdir;
+fn main() {
+    let dir = tempdir().unwrap();
+    let path = dir.keep().unwrap();
+    println!("{:?}", path);
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Insecure creation of temporary build and execution directories in `src/pipeline.rs`. The previous logic used predictable names based on timestamps and process IDs, which is susceptible to symlink attacks and race conditions in shared temporary directories like `/tmp`.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could pre-create a symlink at the predictable path, potentially causing the compiler to overwrite arbitrary files with the user's permissions or hijack the build/execution process.

🛡️ **Solution:** How the fix addresses the vulnerability
The custom logic has been replaced with the `tempfile` crate, which follows security best practices:
1. **Unpredictability:** Uses cryptographically secure random bits for directory names.
2. **Atomicity:** Ensures the directory is created uniquely and fails if it already exists (using `O_EXCL` or equivalent).
3. **Permissions:** Creates directories with restrictive permissions (typically `0700`), preventing other users on the system from accessing or tampering with the contents.
4. **Lifecycle Management:** In `Pipeline::run`, the use of `TempDir` ensures automatic cleanup, reducing the disk footprint of temporary execution files. In `Pipeline::build`, `into_path()` is used to maintain the existing behavior of persisting the build output while securing the creation process itself.

---
*PR created automatically by Jules for task [8179589016143030037](https://jules.google.com/task/8179589016143030037) started by @slavikdev*