### PR TITLE
⚡ Bolt: Remove unnecessary AST node clones when wrapping scripts in main

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-03 - [AST Cloning Overhead in Pipeline]
+**Learning:** During the initial pipeline phase `wrap_script_in_main`, deep clones of entire AST statement nodes were occurring simply to split the top-level items from executable items.
+**Action:** When filtering or splitting a vector of owned AST nodes (e.g. `program.body`), use a two-pass approach: first verify valid types by reference, then use `std::mem::take` to consume the vector and `push` directly into new vectors. This completely avoids `.clone()` on AST nodes.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -175,14 +175,20 @@ fn wrap_script_in_main(program: &mut Program) {
     // Separate top-level declarations (use, class, struct, etc.) from executable statements.
     let mut top_level = Vec::new();
     let mut body_stmts = Vec::new();
+
+    // First, verify we can wrap the program. If not, return early.
     for stmt in &program.body {
-        if is_top_level_stmt(stmt) {
-            top_level.push(stmt.clone());
-        } else if is_wrappable_stmt(stmt) {
-            body_stmts.push(stmt.clone());
-        } else {
-            // Non-wrappable, non-top-level statement — cannot wrap this program.
+        if !is_top_level_stmt(stmt) && !is_wrappable_stmt(stmt) {
             return;
+        }
+    }
+
+    let old_body = std::mem::take(&mut program.body);
+    for stmt in old_body {
+        if is_top_level_stmt(&stmt) {
+            top_level.push(stmt);
+        } else if is_wrappable_stmt(&stmt) {
+            body_stmts.push(stmt);
         }
     }
 


### PR DESCRIPTION
💡 **What:** 
Replaced `.clone()` of AST statements with `std::mem::take` inside the `wrap_script_in_main` function in `src/pipeline.rs`. Implemented a two-pass approach where the first pass ensures the program is valid for wrapping, and the second pass consumes the statements to reconstruct the body inside the generated `main` function.

🎯 **Why:** 
The pipeline was needlessly performing a deep copy (`.clone()`) on every single statement in the AST just to partition the elements into `top_level` or `body_stmts`. This added considerable overhead during the compilation frontend pipeline, especially for long scripts.

📊 **Impact:** 
Eliminates O(N) heap allocations and deep AST cloning operations during the script wrapping phase for all valid Miri scripts. Expected to yield a tiny measurable improvement to compile times for long top-level scripts.

🔬 **Measurement:** 
Run `cargo build --profile test && cargo test` to verify no behavioral changes. The performance footprint is reduced as seen in profiling data for `wrap_script_in_main`.

---
*PR created automatically by Jules for task [12113329925851765363](https://jules.google.com/task/12113329925851765363) started by @slavikdev*