### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unwrap compiler DoS in call member expression parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Compiler DoS via Unexpected EOF on Generic Syntax]
+**Vulnerability:** A panic (`unwrap()`) in the parser's generic arguments handling (`call_member_expression()`) triggered when reaching an unexpected end-of-file.
+**Learning:** `Option::unwrap()` is frequently unsafe around lookahead buffers. Compilers must gracefully handle truncated input at any token stream boundary to avoid DoS.
+**Prevention:** Use pattern matching (`if let Some(...) = self._lookahead`) on lookahead variables and break parsing loops safely on `None` (EOF).

--- a/src/parser/expressions/call_member.rs
+++ b/src/parser/expressions/call_member.rs
@@ -48,7 +48,11 @@ impl<'source> Parser<'source> {
                     // If there is no whitespace, it's a generic argument list.
                     // e.g. `a < b` (comparison), `foo<T>` (generic)
                     let prev_end = expression.span.end;
-                    let current_start = self._lookahead.as_ref().unwrap().1.start;
+                    let current_start = if let Some((_, ref span)) = self._lookahead {
+                        span.start
+                    } else {
+                        break;
+                    };
 
                     if current_start > prev_end {
                         break;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The parser panicked (`unwrap()`) when trying to access the next token's span while parsing generic arguments if it encountered an unexpected end-of-file (EOF), leading to a compiler crash (DoS) on untrusted/malformed code.
🎯 Impact: An attacker could crash the Miri compiler process by supplying truncated source code with incomplete generic argument lists (e.g. `foo<`), resulting in a denial-of-service.
🔧 Fix: Replaced `self._lookahead.as_ref().unwrap().1.start` with a safe `if let Some((_, ref span)) = self._lookahead` pattern match. If the lookahead is `None` (EOF), the parser now gracefully breaks the loop and returns the AST built so far, allowing the normal error reporting mechanism to handle the incomplete syntax instead of panicking.
✅ Verification: Ran `cargo fmt`, `cargo clippy -- -D warnings`, and the full test suite (`cargo test`) to ensure the changes are secure and introduce no regressions. Evaluated under the strict rules of the Sentinel persona.

---
*PR created automatically by Jules for task [5644998092913829206](https://jules.google.com/task/5644998092913829206) started by @slavikdev*