### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Compiler DoS from unhandled EOF in parser

### DIFF
--- a/src/parser/expressions/call_member.rs
+++ b/src/parser/expressions/call_member.rs
@@ -48,7 +48,11 @@ impl<'source> Parser<'source> {
                     // If there is no whitespace, it's a generic argument list.
                     // e.g. `a < b` (comparison), `foo<T>` (generic)
                     let prev_end = expression.span.end;
-                    let current_start = self._lookahead.as_ref().unwrap().1.start;
+                    let current_start = self
+                        ._lookahead
+                        .as_ref()
+                        .map(|(_, span)| span.start)
+                        .unwrap_or(prev_end + 1);
 
                     if current_start > prev_end {
                         break;

--- a/tests/parser/call_member.rs
+++ b/tests/parser/call_member.rs
@@ -1,0 +1,14 @@
+use miri::lexer::Lexer;
+use miri::parser::Parser;
+
+#[test]
+fn test_call_member_unexpected_eof_after_less_than() {
+    let source = "fn foo() { a < }";
+    let mut lexer = Lexer::new(source);
+    let mut parser = Parser::new(&mut lexer, source);
+    let result = parser.parse();
+
+    // We just want to ensure it doesn't panic.
+    // It should ideally return a syntax error about an invalid type declaration.
+    assert!(result.is_err());
+}

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -8,6 +8,7 @@ pub mod basic;
 pub mod binary_expression;
 pub mod boolean;
 pub mod break_statement;
+pub mod call_member;
 pub mod class_statement;
 pub mod conditional_expression;
 pub mod constant_declaration;


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Compiler DoS from unhandled EOF in parser

🚨 Severity: CRITICAL
💡 Vulnerability: The parser panics when encountering an unexpected `Token::LessThan` (Generic argument opening bracket) near the end of the file or input stream due to an `unwrap()` on `self._lookahead`.
🎯 Impact: This causes a compiler Denial of Service (DoS) when parsing untrusted input.
🔧 Fix: Replaced `unwrap()` with `.map(...).unwrap_or(...)` to safely fallback to a break condition (`current_start > prev_end`), ensuring the parsing loop stops safely on unexpected EOFs without panicking. Added a regression test (`tests/parser/call_member.rs`).
✅ Verification: Ran `cargo test`, `cargo fmt`, `cargo check`, and `cargo clippy -- -D warnings`. Verified the `poc.mi` file correctly handles an unexpected EOF without panicking.

---
*PR created automatically by Jules for task [2191850686931272014](https://jules.google.com/task/2191850686931272014) started by @slavikdev*