### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix compiler DoS in lexer indent stack unwrap

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** A panic (`unwrap()`) in the parser's generic arguments handling (`call_member_expression()`) triggered when reaching an unexpected end-of-file.
 **Learning:** `Option::unwrap()` is frequently unsafe around lookahead buffers. Compilers must gracefully handle truncated input at any token stream boundary to avoid DoS.
 **Prevention:** Use pattern matching (`if let Some(...) = self._lookahead`) on lookahead variables and break parsing loops safely on `None` (EOF).
+
+## 2024-05-25 - [Compiler DoS via Unchecked Indent Stack Unwrap]
+**Vulnerability:** The lexer panics (`unwrap()`) when attempting to handle unclosed indentation structures because it assumes the `indent_stack` will never be empty while dedenting.
+**Learning:** Compilers must not trust their own internal state tracking blindly when processing untrusted input streams. An unexpected EOF or malformed whitespace can deplete stacks faster than expected.
+**Prevention:** Use safe pattern matching (e.g., `while let Some(...) = stack.last()`) and break cleanly when stacks are depleted during whitespace processing.

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -306,8 +306,12 @@ impl<'source> Lexer<'source> {
                 }
 
                 // Pop indentation levels and generate Dedent tokens
-                while indent_len < *self.indent_stack.last().unwrap() {
-                    self.push_dedent(token_end);
+                while let Some(&last_indent) = self.indent_stack.last() {
+                    if indent_len < last_indent {
+                        self.push_dedent(token_end);
+                    } else {
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The lexer contains an `unwrap()` call when attempting to process indentation in `src/lexer/mod.rs` (`self.indent_stack.last().unwrap()`). If a malformed token stream depletes the stack unexpectedly or EOF is reached without proper handling, the compiler panics, resulting in a Denial of Service via untrusted source code.
🎯 **Impact:** An attacker or fuzzer can crash the compiler entirely by providing a source file with specifically crafted, malformed whitespace or unclosed blocks at EOF.
🔧 **Fix:** Replaced the panicking `unwrap()` with a safe `while let Some(&last_indent) = self.indent_stack.last()` pattern matching loop that gracefully breaks if the stack is exhausted, avoiding a panic while retaining correct indentation parsing behavior.
✅ **Verification:** Ran `cargo clippy -- -D warnings`, `cargo fmt`, and `cargo test` which all passed. Tested manually by verifying `unwrap` is no longer in `src/lexer/mod.rs`.

---
*PR created automatically by Jules for task [6710363028684905869](https://jules.google.com/task/6710363028684905869) started by @slavikdev*