### PR TITLE
⚡ Bolt: Pre-allocate Vec capacity for type checker candidates

### DIFF
--- a/src/type_checker/expressions/identifiers.rs
+++ b/src/type_checker/expressions/identifiers.rs
@@ -175,7 +175,8 @@ impl TypeChecker {
             ))));
         }
 
-        let capacity = context.scopes.iter().map(|s| s.len()).sum::<usize>() + self.global_scope.len() + 4;
+        let capacity =
+            context.scopes.iter().map(|s| s.len()).sum::<usize>() + self.global_scope.len() + 4;
         let mut candidates: Vec<&str> = Vec::with_capacity(capacity);
         for scope in &context.scopes {
             candidates.extend(scope.keys().map(|s| s.as_str()));

--- a/src/type_checker/expressions/identifiers.rs
+++ b/src/type_checker/expressions/identifiers.rs
@@ -175,7 +175,8 @@ impl TypeChecker {
             ))));
         }
 
-        let mut candidates: Vec<&str> = Vec::new();
+        let capacity = context.scopes.iter().map(|s| s.len()).sum::<usize>() + self.global_scope.len() + 4;
+        let mut candidates: Vec<&str> = Vec::with_capacity(capacity);
         for scope in &context.scopes {
             candidates.extend(scope.keys().map(|s| s.as_str()));
         }

--- a/src/type_checker/utils.rs
+++ b/src/type_checker/utils.rs
@@ -511,7 +511,8 @@ impl TypeChecker {
 
     /// Reports an unknown type error with suggestions.
     fn report_unknown_type(&mut self, name: &str, expr: &Expression, context: &Context) {
-        let mut candidates: Vec<&str> = Vec::new();
+        let capacity = context.type_definitions.iter().map(|s| s.len()).sum::<usize>() + self.global_type_definitions.len() + 6;
+        let mut candidates: Vec<&str> = Vec::with_capacity(capacity);
         for scope in &context.type_definitions {
             candidates.extend(scope.keys().map(|s| s.as_str()));
         }

--- a/src/type_checker/utils.rs
+++ b/src/type_checker/utils.rs
@@ -511,7 +511,13 @@ impl TypeChecker {
 
     /// Reports an unknown type error with suggestions.
     fn report_unknown_type(&mut self, name: &str, expr: &Expression, context: &Context) {
-        let capacity = context.type_definitions.iter().map(|s| s.len()).sum::<usize>() + self.global_type_definitions.len() + 6;
+        let capacity = context
+            .type_definitions
+            .iter()
+            .map(|s| s.len())
+            .sum::<usize>()
+            + self.global_type_definitions.len()
+            + 6;
         let mut candidates: Vec<&str> = Vec::with_capacity(capacity);
         for scope in &context.type_definitions {
             candidates.extend(scope.keys().map(|s| s.as_str()));


### PR DESCRIPTION
💡 **What:** Pre-allocated the `candidates` vector in `src/type_checker/utils.rs` (`report_unknown_type`) and `src/type_checker/expressions/identifiers.rs` (`infer_identifier`) using `Vec::with_capacity`.
🎯 **Why:** To prevent unnecessary heap re-allocations when iterating over multiple scopes and pushing many variable or type names into a vector.
📊 **Impact:** Reduces heap allocations and time spent resizing vectors in the type checker's error reporting paths. While this is primarily an error path, heavily nested scopes could cause significant allocation overhead.
🔬 **Measurement:** This optimization can be observed via memory profiling tools or reduced allocator pressure during compilation of code with many scopes or errors. Checked with `cargo test` and `cargo clippy` to ensure no semantic changes.

---
*PR created automatically by Jules for task [13639010314895941485](https://jules.google.com/task/13639010314895941485) started by @slavikdev*