### PR TITLE
Parser: Disallow protected visibility on type alias declarations

### DIFF
--- a/src/parser/declarations/types.rs
+++ b/src/parser/declarations/types.rs
@@ -34,6 +34,10 @@ impl<'source> Parser<'source> {
         &mut self,
         visibility: MemberVisibility,
     ) -> Result<Statement, SyntaxError> {
+        if visibility == MemberVisibility::Protected {
+            return Err(self.error_unexpected_token("public or private visibility", "protected"));
+        }
+
         self.eat_token(&Token::Type)?;
         let mut declarations = vec![self.type_declaration()?];
 

--- a/tests/parser/type_statement.rs
+++ b/tests/parser/type_statement.rs
@@ -145,17 +145,12 @@ fn test_error_type_statement_missing_identifier() {
 
 #[test]
 fn test_protected_type_alias() {
-    parser_test(
+    parser_error_test(
         "protected type MyInt is int",
-        vec![type_statement(
-            vec![type_declaration(
-                "MyInt",
-                None,
-                TypeDeclarationKind::Is,
-                opt_expr(type_expr_non_null(type_int())),
-            )],
-            MemberVisibility::Protected,
-        )],
+        &SyntaxErrorKind::UnexpectedToken {
+            expected: "public or private visibility".to_string(),
+            found: "protected".to_string(),
+        },
     );
 }
 

--- a/tests/type_checker/type_alias.rs
+++ b/tests/type_checker/type_alias.rs
@@ -288,17 +288,6 @@ type A, B, C
 }
 
 #[test]
-fn test_protected_type_alias() {
-    // TODO: types should be just private or public. Protected is not needed.
-    type_checker_test(
-        "
-protected type InternalInt is int
-let x InternalInt = 5
-",
-    );
-}
-
-#[test]
 fn test_type_alias_deeply_nested() {
     type_checker_error_test(
         "


### PR DESCRIPTION
Fixes an issue where `protected type ...` was technically parseable, even though protected visibility is only intended to be used for class fields/methods. A parser test was updated to correctly assert an error when protected is used, and an old type-checker test containing a TODO for this issue has been removed.

---
*PR created automatically by Jules for task [15789627036015605903](https://jules.google.com/task/15789627036015605903) started by @slavikdev*