### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow and panic in `MiriList` & `MiriArray`

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The lexer panics (`unwrap()`) when attempting to handle unclosed indentation structures because it assumes the `indent_stack` will never be empty while dedenting.
 **Learning:** Compilers must not trust their own internal state tracking blindly when processing untrusted input streams. An unexpected EOF or malformed whitespace can deplete stacks faster than expected.
 **Prevention:** Use safe pattern matching (e.g., `while let Some(...) = stack.last()`) and break cleanly when stacks are depleted during whitespace processing.
+## 2024-05-15 - Unhandled Error in Drop
+**Vulnerability:** `unwrap()` inside `Drop` implementations in core runtime types (`MiriList`, `MiriArray`).
+**Learning:** `unwrap()` in `Drop` is particularly dangerous. If the `unwrap()` panics during unwinding from another panic, it causes an immediate abort of the process (double panic). For memory allocations, an invalid layout can panic the program instead of failing gracefully.
+**Prevention:** Avoid panicking (`unwrap`, `expect`) inside `Drop` handlers. Gracefully swallow errors if there is no way to propagate them, especially since `Drop` cannot return a `Result`.

--- a/src/runtime/core/src/array.rs
+++ b/src/runtime/core/src/array.rs
@@ -34,9 +34,10 @@ impl MiriArray {
 impl Drop for MiriArray {
     fn drop(&mut self) {
         if !self.data.is_null() && self.elem_count > 0 && self.elem_size > 0 {
-            let layout = Layout::from_size_align(self.byte_len(), 8).unwrap();
-            unsafe {
-                dealloc(self.data, layout);
+            if let Ok(layout) = Layout::from_size_align(self.byte_len(), 8) {
+                unsafe {
+                    dealloc(self.data, layout);
+                }
             }
         }
     }

--- a/src/runtime/core/src/list.rs
+++ b/src/runtime/core/src/list.rs
@@ -92,19 +92,23 @@ impl MiriList {
         let new_size = new_capacity * self.elem_size;
         let layout = match Layout::from_size_align(new_size, 8) {
             Ok(layout) => layout,
-            Err(_) => return,
+            Err(_) => std::process::abort(), // Abort safely rather than risking memory corruption
         };
 
         let new_data = if self.data.is_null() {
             unsafe { alloc(layout) }
         } else {
-            let old_layout = Layout::from_size_align(self.capacity * self.elem_size, 8).unwrap();
-            unsafe { realloc(self.data, old_layout, new_size) }
+            match Layout::from_size_align(self.capacity * self.elem_size, 8) {
+                Ok(old_layout) => unsafe { realloc(self.data, old_layout, new_size) },
+                Err(_) => std::process::abort(), // Abort safely rather than risking memory corruption
+            }
         };
 
         if !new_data.is_null() {
             self.data = new_data;
             self.capacity = new_capacity;
+        } else {
+            std::process::abort(); // OOM should also abort safely
         }
     }
 
@@ -237,9 +241,10 @@ impl MiriList {
 impl Drop for MiriList {
     fn drop(&mut self) {
         if !self.data.is_null() && self.capacity > 0 && self.elem_size > 0 {
-            let layout = Layout::from_size_align(self.capacity * self.elem_size, 8).unwrap();
-            unsafe {
-                dealloc(self.data, layout);
+            if let Ok(layout) = Layout::from_size_align(self.capacity * self.elem_size, 8) {
+                unsafe {
+                    dealloc(self.data, layout);
+                }
             }
         }
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unhandled `unwrap()` calls in `Drop` implementations could cause a double panic, leading to an immediate process abort. Additionally, a critical flaw existed in `MiriList::reserve` where allocation or layout calculation failures returned silently. This meant that the list would not actually increase in capacity, but calling code would assume the reservation succeeded, leading to arbitrary out-of-bounds memory writes (buffer overflows).
🎯 **Impact:** Potential for uncatchable process aborts during memory cleanup, and a highly exploitable buffer overflow during dynamic list resizing if memory allocation or capacity math failed.
🔧 **Fix:** Replaced `unwrap()` in `Drop` handlers with safe `if let Ok(...)` blocks. Replaced silent early returns in `MiriList::reserve` with `std::process::abort()` to ensure safe crash over memory corruption.
✅ **Verification:** Ran `cargo clippy -- -D warnings`, `cargo fmt`, and `cargo test` in `src/runtime/core`. Code review successfully passed the patches.

---
*PR created automatically by Jules for task [11379351143328195702](https://jules.google.com/task/11379351143328195702) started by @slavikdev*