### PR TITLE
🧪 Test find_line_info in syntax.rs

### DIFF
--- a/src/error/syntax.rs
+++ b/src/error/syntax.rs
@@ -352,6 +352,8 @@ impl Reportable for SyntaxError {
 pub fn find_line_info(source: &str, pos: usize) -> (usize, usize, &str) {
     let mut line_start = 0;
     let mut line_num = 1;
+    let pos = pos.min(source.len()); // Clamp pos to avoid out-of-bounds slicing
+
     for (i, c) in source.char_indices() {
         if i >= pos {
             break;

--- a/tests/error/syntax.rs
+++ b/tests/error/syntax.rs
@@ -3,7 +3,7 @@
 
 use super::utils::check_diagnostic;
 use miri::error::diagnostic::{Reportable, Severity};
-use miri::error::syntax::{Span, SyntaxErrorKind};
+use miri::error::syntax::{find_line_info, Span, SyntaxErrorKind};
 use miri::error::SyntaxError;
 
 #[test]
@@ -52,4 +52,42 @@ fn test_syntax_error_all_variants_have_codes() {
             kind
         );
     }
+}
+
+#[test]
+fn test_find_line_info() {
+    // Empty string
+    assert_eq!(find_line_info("", 0), (1, 1, ""));
+    assert_eq!(find_line_info("", 10), (1, 1, "")); // Out of bounds behaves gracefully
+
+    // Single line
+    let single = "hello world";
+    assert_eq!(find_line_info(single, 0), (1, 1, "hello world"));
+    assert_eq!(find_line_info(single, 6), (1, 7, "hello world"));
+    assert_eq!(find_line_info(single, single.len()), (1, 12, "hello world")); // EOF
+
+    // Multiple lines
+    let multi = "first\nsecond\nthird";
+    assert_eq!(find_line_info(multi, 0), (1, 1, "first"));
+    assert_eq!(find_line_info(multi, 5), (1, 6, "first"));
+    assert_eq!(find_line_info(multi, 6), (2, 1, "second"));
+    assert_eq!(find_line_info(multi, 10), (2, 5, "second"));
+    assert_eq!(find_line_info(multi, 13), (3, 1, "third"));
+    assert_eq!(find_line_info(multi, multi.len()), (3, 6, "third")); // EOF
+
+    // Out of bounds pos
+    assert_eq!(find_line_info(multi, 100), (3, 6, "third")); // Limits to the end of the last line string
+
+    // Multi-byte characters
+    let unicode = "hëllo\nwörld";
+    // 'ë' is 2 bytes, so 'h' is index 0, 'ë' is index 1..2, 'l' is index 3
+    assert_eq!(find_line_info(unicode, 0), (1, 1, "hëllo")); // 'h'
+    assert_eq!(find_line_info(unicode, 1), (1, 2, "hëllo")); // 'ë'
+    assert_eq!(find_line_info(unicode, 3), (1, 3, "hëllo")); // 'l' (1st)
+    assert_eq!(find_line_info(unicode, 6), (1, 6, "hëllo")); // '\n' (col_num includes preceding chars + 1)
+
+    // Line 2: "wörld" starts at index 7. 'ö' is 2 bytes.
+    assert_eq!(find_line_info(unicode, 7), (2, 1, "wörld")); // 'w'
+    assert_eq!(find_line_info(unicode, 8), (2, 2, "wörld")); // 'ö'
+    assert_eq!(find_line_info(unicode, 10), (2, 3, "wörld")); // 'r'
 }


### PR DESCRIPTION
🎯 **What:** Tested the undocumented and untested `find_line_info` function in `src/error/syntax.rs`. Also fixed an out-of-bounds bounds panic in the function that occurred when `pos > source.len()`.
📊 **Coverage:** Covered single line text, multiline text, unicode strings (multi-byte characters correctly calculating 1-based char counts), empty strings, and out-of-bounds edge cases.
✨ **Result:** Increased test coverage for the syntax error formatting functionality and ensured it is panic-safe when dealing with potentially dirty offset ranges.

---
*PR created automatically by Jules for task [12569459518967931318](https://jules.google.com/task/12569459518967931318) started by @slavikdev*