### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unwrap panics crossing FFI boundaries in core runtime

### DIFF
--- a/src/runtime/core/src/array.rs
+++ b/src/runtime/core/src/array.rs
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn miri_rt_array_free(ptr: *mut MiriArray) {
     // Free internal data buffer
     let arr = &*ptr;
     if !arr.data.is_null() && arr.elem_count > 0 && arr.elem_size > 0 {
-        let layout = Layout::from_size_align(arr.byte_len(), 8).unwrap();
+        let layout = Layout::from_size_align(arr.byte_len(), 8).unwrap_or_else(|_| std::process::abort());
         dealloc(arr.data, layout);
     }
     // Free the [RC][struct] block

--- a/src/runtime/core/src/list.rs
+++ b/src/runtime/core/src/list.rs
@@ -515,7 +515,7 @@ pub unsafe extern "C" fn miri_rt_list_free(ptr: *mut MiriList) {
     // Free internal data buffer
     let list = &*ptr;
     if !list.data.is_null() && list.capacity > 0 && list.elem_size > 0 {
-        let layout = Layout::from_size_align(list.capacity * list.elem_size, 8).unwrap();
+        let layout = Layout::from_size_align(list.capacity * list.elem_size, 8).unwrap_or_else(|_| std::process::abort());
         dealloc(list.data, layout);
     }
     // Free the [RC][struct] block

--- a/src/runtime/core/src/rc.rs
+++ b/src/runtime/core/src/rc.rs
@@ -48,6 +48,6 @@ pub unsafe fn free_with_rc(payload_ptr: *mut u8, payload_size: usize) {
     }
     let base = payload_ptr.sub(RC_HEADER_SIZE);
     let total_size = RC_HEADER_SIZE + payload_size;
-    let layout = Layout::from_size_align(total_size, 8).unwrap();
+    let layout = Layout::from_size_align(total_size, 8).unwrap_or_else(|_| std::process::abort());
     dealloc(base, layout);
 }

--- a/src/runtime/core/src/set.rs
+++ b/src/runtime/core/src/set.rs
@@ -116,8 +116,8 @@ impl MiriSet {
     }
 
     unsafe fn alloc_tables(&mut self, capacity: usize) {
-        let states_layout = Layout::from_size_align(capacity, 1).unwrap();
-        let data_layout = Layout::from_size_align(capacity * self.elem_size, 8).unwrap();
+        let states_layout = Layout::from_size_align(capacity, 1).unwrap_or_else(|_| std::process::abort());
+        let data_layout = Layout::from_size_align(capacity * self.elem_size, 8).unwrap_or_else(|_| std::process::abort());
         self.states = alloc_zeroed(states_layout);
         self.data = alloc_zeroed(data_layout);
         self.capacity = capacity;
@@ -152,11 +152,11 @@ impl MiriSet {
         elem_size: usize,
     ) {
         if !states.is_null() && capacity > 0 {
-            let states_layout = Layout::from_size_align(capacity, 1).unwrap();
+            let states_layout = Layout::from_size_align(capacity, 1).unwrap_or_else(|_| std::process::abort());
             dealloc(states, states_layout);
         }
         if !data.is_null() && capacity > 0 && elem_size > 0 {
-            let data_layout = Layout::from_size_align(capacity * elem_size, 8).unwrap();
+            let data_layout = Layout::from_size_align(capacity * elem_size, 8).unwrap_or_else(|_| std::process::abort());
             dealloc(data, data_layout);
         }
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `unwrap()` calls in `extern "C"` FFI functions (like `miri_rt_list_free`, `alloc_tables`, `free_with_rc`, etc.) would cause the Rust panic machinery to unwind across FFI boundaries if layout calculation failed, resulting in Undefined Behavior (UB) and potential security exploitation.
🎯 Impact: Untrusted input leading to massive allocations or corrupted metadata could trigger panics inside FFI boundaries, leading to uncatchable crashes, memory corruption, or exploitable execution states.
🔧 Fix: Replaced all instances of `Layout::from_size_align(...).unwrap()` with `.unwrap_or_else(|_| std::process::abort())` in the core runtime types (`MiriList`, `MiriSet`, `MiriArray`, and `rc`). This safely and deterministically aborts the process instead of unwinding.
✅ Verification: Ran `cargo test` in the main workspace and `cargo build --release` in `src/runtime/core`. All tests pass, and the UB risk is mitigated.

---
*PR created automatically by Jules for task [2848496818287181137](https://jules.google.com/task/2848496818287181137) started by @slavikdev*