### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** `unwrap()` inside `Drop` implementations in core runtime types (`MiriList`, `MiriArray`).
 **Learning:** `unwrap()` in `Drop` is particularly dangerous. If the `unwrap()` panics during unwinding from another panic, it causes an immediate abort of the process (double panic). For memory allocations, an invalid layout can panic the program instead of failing gracefully.
 **Prevention:** Avoid panicking (`unwrap`, `expect`) inside `Drop` handlers. Gracefully swallow errors if there is no way to propagate them, especially since `Drop` cannot return a `Result`.
+
+## 2024-05-26 - [Path Traversal in Module Imports]
+**Vulnerability:** The type checker allowed arbitrary import paths like `system.io...` that would be transformed into `system/io/...mi` which might resolve paths outside the project source tree or standard library.
+**Learning:** Checking path containment with `canonicalize` only works for paths that actually exist on disk at the moment of the check. It does not stop a path traversal attempt if the constructed string itself is malformed but unresolvable.
+**Prevention:** Explicitly sanitize user-provided strings before constructing `PathBuf` from them to avoid strings like `..`, `/`, or `\`.

--- a/src/type_checker/statements/imports.rs
+++ b/src/type_checker/statements/imports.rs
@@ -65,6 +65,14 @@ impl TypeChecker {
         };
 
         // 2. Resolve file path
+        if path_str.contains("..") || path_str.contains('/') || path_str.contains('\\') {
+            self.report_error(
+                format!("Invalid characters in module path: '{}'", path_str),
+                path.span,
+            );
+            return;
+        }
+
         // Assume src/stdlib for now.
         // Convert "system.io" -> "system/io.mi"
         let relative_path = path_str.replace(".", "/") + ".mi";


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The type checker allowed arbitrary import paths (e.g., `system.io...`) to be transformed and passed into standard path resolution. Because it relied on `canonicalize()` to check for boundaries, malformed strings could bypass validation if the file didn't exist, leading to potential path traversal out of the designated `src/stdlib` directory.
🎯 **Impact:** An attacker or malicious source file could include out-of-bounds paths to probe or read host filesystem files during compilation.
🔧 **Fix:** Added explicit character checking to `path_str` before it is transformed or passed to `PathBuf`. The compiler now reports a syntax error and aborts the import if it detects `..`, `/`, or `\` in the path string.
✅ **Verification:** Ran `cd src/runtime/core && cargo build --release`, followed by `cargo clippy -- -D warnings`, `cargo fmt`, and the full test suite (`cargo test`), ensuring no regressions. Addressed the vulnerability and added a `sentinel.md` journal entry.

---
*PR created automatically by Jules for task [10815360893521567490](https://jules.google.com/task/10815360893521567490) started by @slavikdev*