### PR TITLE
🧪 [testing improvement] Add test for AST factory Type::new

### DIFF
--- a/tests/ast/mod.rs
+++ b/tests/ast/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Viacheslav Shynkarenko
+
+pub mod types;

--- a/tests/ast/types.rs
+++ b/tests/ast/types.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Viacheslav Shynkarenko
+
+use miri::ast::types::{Type, TypeKind};
+use miri::error::syntax::Span;
+
+#[test]
+fn test_type_new() {
+    let kind = TypeKind::Int;
+    let span = Span { start: 10, end: 20 };
+    let typ = Type::new(kind.clone(), span);
+
+    assert_eq!(typ.kind, kind);
+    assert_eq!(typ.span, span);
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) Viacheslav Shynkarenko
 
+pub mod ast;
 pub mod cli;
 pub mod codegen;
 pub mod e2e;


### PR DESCRIPTION
🎯 **What:** The AST node factory `Type::new` within `src/ast/types.rs` lacked explicit testing.
📊 **Coverage:** A new unit test `test_type_new` was created in `tests/ast/types.rs` which verifies the initialization of `TypeKind` and `Span` properties when generating a new `Type` instance using `Type::new`.
✨ **Result:** Test suite coverage has increased specifically for abstract syntax tree factories, providing explicit validation for core primitive construction behavior, enabling confident refactoring around parsing and abstract models.

---
*PR created automatically by Jules for task [1519045791969144360](https://jules.google.com/task/1519045791969144360) started by @slavikdev*