### PR TITLE
⚡ Bolt: Replace String clones with string slices in type cycle detection

### DIFF
--- a/src/type_checker/utils.rs
+++ b/src/type_checker/utils.rs
@@ -935,16 +935,16 @@ impl TypeChecker {
         self.contains_type_directly(target_name, ty, &mut visited)
     }
 
-    fn contains_type_directly(
-        &self,
+    fn contains_type_directly<'a>(
+        &'a self,
         target_name: &str,
-        ty: &TypeKind,
-        visited: &mut std::collections::HashSet<String>,
+        ty: &'a TypeKind,
+        visited: &mut std::collections::HashSet<&'a str>,
     ) -> bool {
         match ty {
             TypeKind::Custom(name, _) if name == target_name => true,
             TypeKind::Custom(name, _) => {
-                if !visited.insert(name.clone()) {
+                if !visited.insert(name.as_str()) {
                     return false; // Already checked, avoid infinite loop
                 }
                 // Check if this custom type transitively contains target_name


### PR DESCRIPTION
### 💡 What
Updated `contains_type_directly` in `src/type_checker/utils.rs` to use `HashSet<&'a str>` instead of `HashSet<String>` for tracking visited types during recursive resolution checks.

### 🎯 Why
Type cycle detection can be a very hot path during compilation, especially when there are deeply nested or heavily referenced custom types. Using `.clone()` to populate a string-based visited set causes continuous, unnecessary heap allocations. Borrowing the existing string slices (`&str`) from the parsed `TypeKind::Custom` prevents this overhead entirely, following the same optimized pattern already present in `is_auto_copy_inner`.

### 📊 Impact
Eliminates one `String` heap allocation (`name.clone()`) for every custom type visited during `is_infinite_recursive_type` checks in the Type Checker. This improves compilation performance and lowers memory usage on highly complex schemas.

### 🔬 Measurement
Run `cargo clippy -- -D warnings` and `cargo test` to verify correctness. The generated behavior is identical, verified by a full pass on the integration test suite.

---
*PR created automatically by Jules for task [329615677972626888](https://jules.google.com/task/329615677972626888) started by @slavikdev*