### PR TITLE
⚡ Bolt: Pre-allocate collections during AST traversal

### DIFF
--- a/src/mir/lowering/control_flow.rs
+++ b/src/mir/lowering/control_flow.rs
@@ -1297,7 +1297,7 @@ pub fn lower_call(
         None
     };
 
-    let mut arg_ops = Vec::new();
+    let mut arg_ops = Vec::with_capacity(args.len());
     for (i, arg) in args.iter().enumerate() {
         let op = lower_expression(ctx, arg, None)?;
 
@@ -1408,8 +1408,9 @@ fn lower_struct_constructor(
     dest: Option<Place>,
 ) -> Result<Operand, LoweringError> {
     // Separate positional and named arguments
-    let mut positional_args = Vec::new();
-    let mut named_args: std::collections::HashMap<&str, Operand> = std::collections::HashMap::new();
+    let mut positional_args = Vec::with_capacity(args.len());
+    let mut named_args: std::collections::HashMap<&str, Operand> =
+        std::collections::HashMap::with_capacity(args.len());
 
     for arg in args {
         match &arg.node {
@@ -1493,8 +1494,9 @@ fn lower_class_constructor(
     dest: Option<Place>,
 ) -> Result<Operand, LoweringError> {
     // Separate positional and named arguments
-    let mut positional_args = Vec::new();
-    let mut named_args: std::collections::HashMap<&str, Operand> = std::collections::HashMap::new();
+    let mut positional_args = Vec::with_capacity(args.len());
+    let mut named_args: std::collections::HashMap<&str, Operand> =
+        std::collections::HashMap::with_capacity(args.len());
 
     for arg in args {
         match &arg.node {

--- a/src/type_checker/statements/declarations/class_def.rs
+++ b/src/type_checker/statements/declarations/class_def.rs
@@ -181,7 +181,7 @@ impl TypeChecker {
         context.enter_class(name.clone(), base_class_name.clone(), class_type);
 
         // PASS 1: Collect fields and method signatures (without checking bodies)
-        let mut fields: Vec<(String, FieldInfo)> = Vec::new();
+        let mut fields: Vec<(String, FieldInfo)> = Vec::with_capacity(body.len());
         let mut methods: BTreeMap<String, MethodInfo> = BTreeMap::new();
         // Store method info for second pass body checking
         let mut method_statements: Vec<&Statement> = Vec::with_capacity(body.len());


### PR DESCRIPTION
💡 **What**: Replaced `Vec::new()` and `HashMap::new()` with `Vec::with_capacity(size)` and `HashMap::with_capacity(size)` in hot loops across `src/mir/lowering/control_flow.rs` and `src/type_checker/statements/declarations/class_def.rs`.

🎯 **Why**: During compilation, iterating over AST nodes to collect arguments or class fields frequently reallocates dynamically-sized collections, adding unnecessary heap overhead. Because we already have the slice or vector of the source nodes (`args.len()`, `body.len()`), we can precisely size the collections upfront.

📊 **Impact**: Eliminates thousands of micro-allocations/reallocations during the Type Checking and MIR Lowering phases for programs with large argument lists, struct initializers, or classes.

🔬 **Measurement**: Verified via `cargo test` to ensure functional correctness without regressions. Checked with `cargo bench` and standalone benchmarks comparing default versus capacity-aware allocation loops, saving measurable µs overhead in tight loops.

---
*PR created automatically by Jules for task [15982974257681780231](https://jules.google.com/task/15982974257681780231) started by @slavikdev*