### PR TITLE
⚡ Bolt: Pre-allocate generic definitions vector in type statements

### DIFF
--- a/src/type_checker/statements/mod.rs
+++ b/src/type_checker/statements/mod.rs
@@ -207,7 +207,7 @@ impl TypeChecker {
                         if let Some(target) = target_expr {
                             // Extract generic definitions from the generics expression
                             let generic_defs = if let Some(gens) = generics {
-                                let mut defs = Vec::new();
+                                let mut defs = Vec::with_capacity(gens.len());
                                 for gen in gens {
                                     if let ExpressionKind::GenericType(
                                         name_expr,


### PR DESCRIPTION
💡 **What:** Modified `src/type_checker/statements/mod.rs` to initialize the `defs` vector using `Vec::with_capacity(gens.len())` instead of `Vec::new()` when extracting generic definitions from type statements.
🎯 **Why:** When parsing generic type aliases or declarations (e.g., `type MyMap<K, V> is Map<K, V>`), the exact number of generic parameters (`gens.len()`) is statically known before the collection loop begins. Using `Vec::new()` causes the vector to dynamically reallocate memory on the heap as elements are pushed. Pre-allocating the vector avoids these unnecessary intermediate heap reallocations.
📊 **Impact:** Completely eliminates dynamic array reallocations during the extraction of generic type definitions in the Type Checker. This slightly reduces memory pressure and CPU overhead in a hot compilation pipeline path.
🔬 **Measurement:** This optimization aligns with standard Rust performance lint guidelines (e.g., pre-allocation of collections with known size). Compilation passes without regressions, and `cargo clippy` performance checks pass cleanly.

---
*PR created automatically by Jules for task [12853771278913716568](https://jules.google.com/task/12853771278913716568) started by @slavikdev*