### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded recursion in parser

### DIFF
--- a/src/error/syntax.rs
+++ b/src/error/syntax.rs
@@ -76,6 +76,8 @@ pub enum SyntaxErrorKind {
         reason: String,
     },
 
+    RecursionLimitExceeded,
+
     /// An unknown runtime name was specified in a runtime function declaration.
     UnknownRuntime {
         name: String,
@@ -282,6 +284,12 @@ impl SyntaxErrorKind {
                 title: "Invalid Modifier Combination",
                 message: None,
                 help: Some("These modifiers cannot be used together.".to_string()),
+            },
+            Self::RecursionLimitExceeded => ErrorProperties {
+                code: "E0035",
+                title: "Recursion Limit Exceeded",
+                message: None,
+                help: Some("The expression or statement is nested too deeply. Simplify your code.".to_string()),
             },
             Self::UnknownRuntime { name } => ErrorProperties {
                 code: "E0032",

--- a/src/parser/expressions/assignment.rs
+++ b/src/parser/expressions/assignment.rs
@@ -13,7 +13,22 @@ impl<'source> Parser<'source> {
     /*
      */
     pub(crate) fn expression(&mut self) -> Result<Expression, SyntaxError> {
-        self.assignment_expression()
+        self.depth += 1;
+        if self.depth > crate::parser::MAX_PARSE_DEPTH {
+            self.depth -= 1;
+            let span = self
+                ._lookahead
+                .as_ref()
+                .map(|(_, s)| *s)
+                .unwrap_or(crate::error::syntax::Span::new(0, 0));
+            return Err(SyntaxError::new(
+                crate::error::syntax::SyntaxErrorKind::RecursionLimitExceeded,
+                span,
+            ));
+        }
+        let res = self.assignment_expression();
+        self.depth -= 1;
+        res
     }
 
     /*

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -19,6 +19,9 @@ pub(crate) struct DeclarationBlockConfig<'a> {
     pub missing_members_error: SyntaxErrorKind,
 }
 
+/// Maximum recursion depth allowed during parsing to prevent stack overflow DoS attacks.
+pub const MAX_PARSE_DEPTH: usize = 256;
+
 /// Recursive descent parser for Miri source code.
 ///
 /// Consumes tokens from a `Lexer` and produces a `Program` AST.
@@ -27,6 +30,7 @@ pub struct Parser<'source> {
     pub(super) lexer: &'source mut Lexer<'source>,
     pub(super) source: &'source str,
     pub(super) _lookahead: Option<TokenSpan>,
+    pub(super) depth: usize,
 }
 
 impl<'source> Parser<'source> {
@@ -36,6 +40,7 @@ impl<'source> Parser<'source> {
             lexer,
             source,
             _lookahead: None,
+            depth: 0,
         }
     }
 

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -48,6 +48,25 @@ impl<'source> Parser<'source> {
             ;
     */
     pub(crate) fn statement(&mut self) -> Result<Statement, SyntaxError> {
+        self.depth += 1;
+        if self.depth > crate::parser::MAX_PARSE_DEPTH {
+            self.depth -= 1;
+            let span = self
+                ._lookahead
+                .as_ref()
+                .map(|(_, s)| *s)
+                .unwrap_or(crate::error::syntax::Span::new(0, 0));
+            return Err(SyntaxError::new(
+                crate::error::syntax::SyntaxErrorKind::RecursionLimitExceeded,
+                span,
+            ));
+        }
+        let res = self.statement_internal();
+        self.depth -= 1;
+        res
+    }
+
+    fn statement_internal(&mut self) -> Result<Statement, SyntaxError> {
         if self._lookahead.is_none() {
             return Ok(ast::empty_statement());
         }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix unbounded recursion in parser

Severity: CRITICAL
Vulnerability: Unbounded recursion (Stack Overflow DoS) during parsing of deeply nested expressions and statements.
Impact: An attacker can crash the compiler via a Stack Overflow DoS by providing malicious input code with extremely deep nesting.
Fix: Added a `depth` tracking field to the parser and a `MAX_PARSE_DEPTH` constant. Checked this depth during critical recursive parsing methods (`expression` and `statement`). Exceeding this limit returns a new `RecursionLimitExceeded` error variant securely without panicking.
Verification: The change is thoroughly verified by `cargo check` and full `cargo test`.

---
*PR created automatically by Jules for task [4745454996524150922](https://jules.google.com/task/4745454996524150922) started by @slavikdev*