### PR TITLE
Enable string equality support test

### DIFF
--- a/tests/type_checker/boolean.rs
+++ b/tests/type_checker/boolean.rs
@@ -39,7 +39,7 @@ fn test_equality() {
         ("1 == 1", type_bool()),
         ("1 != 2", type_bool()),
         ("1.5 == 1.5", type_bool()),
-        // ("\"a\" == \"b\"", type_bool()), // TODO: Enable when string equality is supported
+        ("\"a\" == \"b\"", type_bool()),
     ]);
 }
 


### PR DESCRIPTION
This change enables a previously commented-out test case for string equality in the type checker. Analysis of `src/type_checker/compatibility.rs` and `src/type_checker/operators.rs` confirmed that string types are treated as compatible for comparison operations, making this test case now valid and ready for inclusion in the suite.

---
*PR created automatically by Jules for task [8716008906067118271](https://jules.google.com/task/8716008906067118271) started by @slavikdev*