### PR TITLE
🧪 test: add tests for version_string in src/cli/version.rs

### DIFF
--- a/tests/cli/version.rs
+++ b/tests/cli/version.rs
@@ -14,6 +14,21 @@ fn test_version_flag() {
 }
 
 #[test]
+fn test_version_string_content() {
+    let version = miri::cli::version_string();
+    assert!(version.contains(VERSION));
+    assert!(version.contains(std::env::consts::OS));
+    assert!(version.contains(std::env::consts::ARCH));
+}
+
+#[test]
+fn test_version_ref_content() {
+    let version_str = miri::cli::version_string();
+    let version_ref = miri::cli::version_ref();
+    assert_eq!(version_str, version_ref);
+}
+
+#[test]
 fn test_short_version_flag() {
     let mut cmd = miri_cmd();
     let expected = format!("{} {}", BINARY_NAME, VERSION);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for `version_string` in `src/cli/version.rs`.
📊 **Coverage:** What scenarios are now tested:
- `test_version_string_content`: Verifies the content of the version string matches the expected format (contains version, OS, and arch).
- `test_version_ref_content`: Verifies that `version_ref` returns the same string as `version_string`.
✨ **Result:** Increased test coverage for the CLI version utility functions. Verified logic using standalone `rustc` due to environment-specific `cargo` network limitations.

---
*PR created automatically by Jules for task [14524550250333823310](https://jules.google.com/task/14524550250333823310) started by @slavikdev*