### PR TITLE
⚡ Bolt: Optimize Display format loops by replacing `if i > 0` with `split_first()`

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -231,11 +231,11 @@ impl fmt::Display for TypeKind {
                 write!(f, "{}", name)?;
                 if let Some(args) = args {
                     write!(f, "<")?;
-                    for (i, arg) in args.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = args.split_first() {
+                        write!(f, "{}", first.node)?;
+                        for arg in rest {
+                            write!(f, ", {}", arg.node)?;
                         }
-                        write!(f, "{}", arg.node)?;
                     }
                     write!(f, ">")?;
                 }

--- a/src/mir/rvalue.rs
+++ b/src/mir/rvalue.rs
@@ -91,104 +91,107 @@ impl fmt::Display for Rvalue {
             Rvalue::Aggregate(kind, ops) => match kind {
                 AggregateKind::Tuple => {
                     write!(f, "(")?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{}", first)?;
+                        for op in rest {
+                            write!(f, ", {}", op)?;
                         }
-                        write!(f, "{}", op)?;
                     }
                     write!(f, ")")
                 }
                 AggregateKind::FormattedString => {
                     write!(f, "f\"")?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{{{}}}", first)?;
+                        for op in rest {
+                            write!(f, ", {{{}}}", op)?;
                         }
-                        write!(f, "{{{}}}", op)?;
                     }
                     write!(f, "\"")
                 }
                 AggregateKind::Array | AggregateKind::List => {
                     write!(f, "[")?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{}", first)?;
+                        for op in rest {
+                            write!(f, ", {}", op)?;
                         }
-                        write!(f, "{}", op)?;
                     }
                     write!(f, "]")
                 }
                 AggregateKind::Set => {
                     write!(f, "{{")?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{}", first)?;
+                        for op in rest {
+                            write!(f, ", {}", op)?;
                         }
-                        write!(f, "{}", op)?;
                     }
                     write!(f, "}}")
                 }
                 AggregateKind::Map => {
                     write!(f, "{{")?;
-                    for (i, chunk) in ops.chunks(2).enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    let mut chunks = ops.chunks(2);
+                    if let Some(first) = chunks.next() {
+                        if first.len() == 2 {
+                            write!(f, "{}: {}", first[0], first[1])?;
                         }
-                        if chunk.len() == 2 {
-                            write!(f, "{}: {}", chunk[0], chunk[1])?;
+                        for chunk in chunks {
+                            if chunk.len() == 2 {
+                                write!(f, ", {}: {}", chunk[0], chunk[1])?;
+                            }
                         }
                     }
                     write!(f, "}}")
                 }
                 AggregateKind::Struct(ty) | AggregateKind::Class(ty) => {
                     write!(f, "{} {{ ", ty)?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{}", first)?;
+                        for op in rest {
+                            write!(f, ", {}", op)?;
                         }
-                        write!(f, "{}", op)?;
                     }
                     write!(f, " }}")
                 }
                 AggregateKind::Enum(type_name, variant_name) => {
                     write!(f, "{}.{}(", type_name, variant_name)?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{}", first)?;
+                        for op in rest {
+                            write!(f, ", {}", op)?;
                         }
-                        write!(f, "{}", op)?;
                     }
                     write!(f, ")")
                 }
                 AggregateKind::Option => {
                     write!(f, "Some(")?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{}", first)?;
+                        for op in rest {
+                            write!(f, ", {}", op)?;
                         }
-                        write!(f, "{}", op)?;
                     }
                     write!(f, ")")
                 }
                 AggregateKind::Closure(name, _) => {
                     write!(f, "closure<{}>(", name)?;
-                    for (i, op) in ops.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+                    if let Some((first, rest)) = ops.split_first() {
+                        write!(f, "{}", first)?;
+                        for op in rest {
+                            write!(f, ", {}", op)?;
                         }
-                        write!(f, "{}", op)?;
                     }
                     write!(f, ")")
                 }
             },
             Rvalue::Phi(args) => {
                 write!(f, "phi(")?;
-                for (i, (op, block)) in args.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
+                if let Some((first, rest)) = args.split_first() {
+                    write!(f, "[ {}, {} ]", first.0, first.1)?;
+                    for (op, block) in rest {
+                        write!(f, ", [ {}, {} ]", op, block)?;
                     }
-                    write!(f, "[ {}, {} ]", op, block)?;
                 }
                 write!(f, ")")
             }

--- a/src/mir/terminator.rs
+++ b/src/mir/terminator.rs
@@ -150,11 +150,11 @@ impl fmt::Display for Terminator {
                 target,
             } => {
                 write!(f, "{} = {}(", destination, func)?;
-                for (i, arg) in args.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
+                if let Some((first, rest)) = args.split_first() {
+                    write!(f, "{}", first)?;
+                    for arg in rest {
+                        write!(f, ", {}", arg)?;
                     }
-                    write!(f, "{}", arg)?;
                 }
                 write!(f, ") -> ")?;
                 if let Some(t) = target {
@@ -188,11 +188,11 @@ impl fmt::Display for Terminator {
                 target,
             } => {
                 write!(f, "{} = vcall[{}](", destination, vtable_slot)?;
-                for (i, arg) in args.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
+                if let Some((first, rest)) = args.split_first() {
+                    write!(f, "{}", first)?;
+                    for arg in rest {
+                        write!(f, ", {}", arg)?;
                     }
-                    write!(f, "{}", arg)?;
                 }
                 write!(f, ") -> ")?;
                 if let Some(t) = target {


### PR DESCRIPTION
💡 **What:** Replaced `if i > 0` branching conditions inside `fmt::Display` formatting loops with the more idiomatic `split_first()` approach across `src/ast/types.rs`, `src/mir/rvalue.rs`, and `src/mir/terminator.rs`.
🎯 **Why:** To eliminate an unnecessary conditional branch check (`if i > 0`) on every single iteration of loops that format comma-separated lists of elements (like arrays, tuples, arguments, generics, etc.).
📊 **Impact:** This is a targeted micro-optimization that technically improves the performance of compiler formatting/dumping operations, while significantly improving code readability and maintainability by using a standard idiomatic Rust pattern.
🔬 **Measurement:** Code logic remains identical, but the execution path avoids branching. Verified by running the test suite (`cargo test`) which passes successfully.

---
*PR created automatically by Jules for task [14332859914616576513](https://jules.google.com/task/14332859914616576513) started by @slavikdev*