### PR TITLE
🛡️ Sentinel: [security improvement] Replace unwrap in type checker with safe matching

### DIFF
--- a/src/type_checker/builtins.rs
+++ b/src/type_checker/builtins.rs
@@ -154,9 +154,10 @@ mod tests {
 
         if let Some(TypeDefinition::Struct(def)) = types.get("Future") {
             assert!(def.generics.is_some());
-            let generics = def.generics.as_ref().unwrap();
-            assert_eq!(generics.len(), 1);
-            assert_eq!(generics[0].name, "T");
+            if let Some(generics) = def.generics.as_ref() {
+                assert_eq!(generics.len(), 1);
+                assert_eq!(generics[0].name, "T");
+            }
         } else {
             panic!("Future should be a struct");
         }

--- a/src/type_checker/expressions/types.rs
+++ b/src/type_checker/expressions/types.rs
@@ -239,7 +239,12 @@ impl TypeChecker {
                 let expr_type = self.infer_expression(expr, context);
                 match expr_type.kind {
                     TypeKind::Function(func_data) if func_data.generics.is_some() => {
-                        let params = func_data.generics.as_ref().unwrap();
+                        let params = if let Some(p) = func_data.generics.as_ref() {
+                            p
+                        } else {
+                            // Should not happen since we matched on `is_some()`
+                            return make_type(TypeKind::Error);
+                        };
                         let func_params = &func_data.params;
                         let ret = &func_data.return_type;
                         let mut mapping = HashMap::new();


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Replace unwrap in type checker with safe matching

Severity: MEDIUM
Vulnerability: `unwrap()` usage in type checker tests and match guards logic
Impact: Minor/None directly, but removing `unwrap()` increases code resilience.
Fix: Replaced `unwrap()` calls with proper `if let Some` match guards in `builtins.rs` and `types.rs`.
Verification: `cargo test` and `cargo check` pass successfully.

---
*PR created automatically by Jules for task [16412208766215033084](https://jules.google.com/task/16412208766215033084) started by @slavikdev*