### PR TITLE
Validate specific error message for missing abstract method override

### DIFF
--- a/tests/integration/oop/abstract_methods.rs
+++ b/tests/integration/oop/abstract_methods.rs
@@ -266,7 +266,6 @@ fn main()
 
 #[test]
 fn test_non_abstract_class_missing_override_is_error() {
-    // TODO: needs to validate the specific error message
     assert_compiler_error(
         r#"
 abstract class Animal
@@ -277,7 +276,7 @@ class Dog extends Animal
 fn main()
     let d = Dog()
     "#,
-        "speak",
+        "Class 'Dog' must implement abstract method 'speak' from class 'Animal'",
     );
 }
 


### PR DESCRIPTION
Updated `tests/integration/oop/abstract_methods.rs` to replace the generic 'speak' error assertion with the specific compiler error message: 'Class 'Dog' must implement abstract method 'speak' from class 'Animal''. This ensures more robust validation of the compiler's error reporting for missing abstract method overrides.

---
*PR created automatically by Jules for task [12468209538874933830](https://jules.google.com/task/12468209538874933830) started by @slavikdev*