### PR TITLE
🛡️ Sentinel: [HIGH] Fix integer overflow UB in map deallocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** `unwrap()` inside `Drop` implementations in core runtime types (`MiriList`, `MiriArray`).
 **Learning:** `unwrap()` in `Drop` is particularly dangerous. If the `unwrap()` panics during unwinding from another panic, it causes an immediate abort of the process (double panic). For memory allocations, an invalid layout can panic the program instead of failing gracefully.
 **Prevention:** Avoid panicking (`unwrap`, `expect`) inside `Drop` handlers. Gracefully swallow errors if there is no way to propagate them, especially since `Drop` cannot return a `Result`.
+
+## 2024-05-26 - [Integer Overflow UB in Layout Calculation]
+**Vulnerability:** Potential Integer Overflow during capacity calculations in `free_buffers` of `src/runtime/core/src/map.rs` where `capacity * key_size` is calculated.
+**Learning:** Raw memory deallocation operations using `Layout::from_size_align` can accept incorrect wrapped-around integer values resulting in Undefined Behavior (UB) if the size overflows `usize`.
+**Prevention:** Use `checked_mul` (e.g. `capacity.checked_mul(key_size)`) to detect overflow during manual memory management operations.

--- a/src/runtime/core/src/map.rs
+++ b/src/runtime/core/src/map.rs
@@ -214,14 +214,17 @@ impl MiriMap {
             }
         }
         if !keys.is_null() {
-            if let Ok(layout) = Layout::from_size_align(capacity * key_size, 8) {
-                dealloc(keys, layout);
+            if let Some(key_total) = capacity.checked_mul(key_size) {
+                if let Ok(layout) = Layout::from_size_align(key_total, 8) {
+                    dealloc(keys, layout);
+                }
             }
         }
         if !values.is_null() {
-            let val_total = capacity * value_size.max(1);
-            if let Ok(layout) = Layout::from_size_align(val_total, 8) {
-                dealloc(values, layout);
+            if let Some(val_total) = capacity.checked_mul(value_size.max(1)) {
+                if let Ok(layout) = Layout::from_size_align(val_total, 8) {
+                    dealloc(values, layout);
+                }
             }
         }
     }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Potential Integer Overflow during capacity calculations in `free_buffers` of `MiriMap` (`src/runtime/core/src/map.rs`).
🎯 **Impact:** When calculating buffer sizes like `capacity * key_size` for deallocation layout matching, an integer overflow could wrap the total size back to a very small integer. If this occurs, `Layout::from_size_align` will succeed but construct a fundamentally incorrect layout descriptor. Releasing the underlying allocation with this malformed layout causes Undefined Behavior (UB), which can manifest as memory corruption or unpredictable application crashes at the FFI boundary.
🔧 **Fix:** Replaced standard arithmetic operators (`*`) with `checked_mul()` during capacity/size aggregations. If the multiplication overflows `usize`, it returns `None`, safely preventing the execution of `dealloc` with invalid layouts. This trades a potential, catastrophic runtime panic/UB for a deterministic memory leak inside a failing component execution.
✅ **Verification:** Ran `cargo clippy -- -D warnings`, built the runtime core, and ran all unit/integration tests with `cargo test` successfully. Verified that no logic was structurally altered and no regressions were introduced.

---
*PR created automatically by Jules for task [4983557285141537774](https://jules.google.com/task/4983557285141537774) started by @slavikdev*