### PR TITLE
⚡ Bolt: Optimize symbol mangling in MIR lowering and Cranelift translator

### DIFF
--- a/src/codegen/cranelift/translator.rs
+++ b/src/codegen/cranelift/translator.rs
@@ -1985,7 +1985,11 @@ impl<'a> FunctionTranslator<'a> {
             if let Some(method) = cd.methods.get(method_name) {
                 // Only use this implementation if it has a body (not abstract).
                 if !method.is_abstract {
-                    return Some(format!("{}_{}", current, method_name));
+                    let mut mangled = String::with_capacity(current.len() + 1 + method_name.len());
+                    mangled.push_str(&current);
+                    mangled.push('_');
+                    mangled.push_str(method_name);
+                    return Some(mangled);
                 }
             }
             all_traits.extend(cd.traits.iter().cloned());
@@ -2004,7 +2008,12 @@ impl<'a> FunctionTranslator<'a> {
             if let Some(TypeDefinition::Trait(td)) = type_definitions.get(&t_name) {
                 if let Some(method) = td.methods.get(method_name) {
                     if !method.is_abstract {
-                        return Some(format!("{}_{}", t_name, method_name));
+                        let mut mangled =
+                            String::with_capacity(t_name.len() + 1 + method_name.len());
+                        mangled.push_str(&t_name);
+                        mangled.push('_');
+                        mangled.push_str(method_name);
+                        return Some(mangled);
                     }
                 }
                 trait_stack.extend(td.parent_traits.iter().cloned());

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -552,7 +552,12 @@ impl Pipeline {
                                 method_decl.name
                             );
 
-                            let mangled = format!("{}_{}", class_name, method_decl.name);
+                            let mut mangled = String::with_capacity(
+                                class_name.len() + 1 + method_decl.name.len(),
+                            );
+                            mangled.push_str(class_name);
+                            mangled.push('_');
+                            mangled.push_str(&method_decl.name);
                             if lowered_names.contains(&mangled) {
                                 continue;
                             }
@@ -597,7 +602,12 @@ impl Pipeline {
                                 continue;
                             }
 
-                            let mangled = format!("{}_{}", trait_name, method_decl.name);
+                            let mut mangled = String::with_capacity(
+                                trait_name.len() + 1 + method_decl.name.len(),
+                            );
+                            mangled.push_str(trait_name);
+                            mangled.push('_');
+                            mangled.push_str(&method_decl.name);
                             if lowered_names.contains(&mangled) {
                                 continue;
                             }
@@ -692,7 +702,12 @@ impl Pipeline {
                                 method_decl.name
                             );
 
-                            let mangled = format!("{}_{}", class_name, method_decl.name);
+                            let mut mangled = String::with_capacity(
+                                class_name.len() + 1 + method_decl.name.len(),
+                            );
+                            mangled.push_str(class_name);
+                            mangled.push('_');
+                            mangled.push_str(&method_decl.name);
                             if lowered_names.contains(&mangled) {
                                 continue;
                             }


### PR DESCRIPTION
💡 What: Replaced occurrences of `format!("{}_{}", a, b)` with `String::with_capacity`, `push_str`, and `push` in `src/pipeline.rs` and `src/codegen/cranelift/translator.rs`.
🎯 Why: The MIR lowering pipeline repeatedly generates mangled names using the `format!` macro, which adds unnecessary runtime overhead (format string parsing) and allocates more heap memory than necessary. 
📊 Impact: Reduces dynamic heap allocations and avoids format string parsing in hot MIR translation paths.
🔬 Measurement: Verified with `cargo build --release` in `src/runtime/core` and `cargo test` in the workspace root.

---
*PR created automatically by Jules for task [13280925138496950848](https://jules.google.com/task/13280925138496950848) started by @slavikdev*