### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix integer overflow in map.rs Layout calculation

### DIFF
--- a/src/runtime/core/src/map.rs
+++ b/src/runtime/core/src/map.rs
@@ -172,9 +172,10 @@ impl MiriMap {
             return None;
         }
         let states_layout = Layout::from_size_align(capacity, 1).ok()?;
-        let keys_layout = Layout::from_size_align(capacity * key_size, 8).ok()?;
+        let key_total = capacity.checked_mul(key_size)?;
+        let keys_layout = Layout::from_size_align(key_total, 8).ok()?;
         // value_size can be 0 for value-less maps (unlikely but safe)
-        let val_total = capacity * value_size.max(1);
+        let val_total = capacity.checked_mul(value_size.max(1))?;
         let values_layout = Layout::from_size_align(val_total, 8).ok()?;
 
         let states = alloc_zeroed(states_layout);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Integer overflow in MiriMap's `alloc_tables` calculation for the required memory layout. It was manually computing `capacity * key_size` and `capacity * value_size.max(1)`. Large capacities could wrap around causing under-allocation of the backing memory.
🎯 Impact: Heap Buffer Overflow during insertion if a very large map is created, potentially leading to memory corruption or DoS.
🔧 Fix: Swapped the unchecked multiplications with `checked_mul`. This allows `alloc_tables` to safely return `None`, propagating an allocation failure without risking a smaller-than-necessary layout size.
✅ Verification: Ran `cargo test`, `cargo clippy -- -D warnings`, and `cargo fmt`. All runtime core tests passed successfully.

---
*PR created automatically by Jules for task [18330869029989210592](https://jules.google.com/task/18330869029989210592) started by @slavikdev*