### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in dynamically built binary execution

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -399,7 +399,20 @@ impl Pipeline {
 
         self.build(source, &build_opts)?;
 
-        let output = Command::new(&executable_path)
+        let canonical_temp_path = temp_dir.path().canonicalize().map_err(|e| {
+            CompilerError::Codegen(format!("Failed to canonicalize temp dir: {}", e))
+        })?;
+        let canonical_exec_path = executable_path.canonicalize().map_err(|e| {
+            CompilerError::Codegen(format!("Failed to canonicalize executable path: {}", e))
+        })?;
+
+        if !canonical_exec_path.starts_with(&canonical_temp_path) {
+            return Err(CompilerError::Codegen(
+                "Security violation: Executable path is outside the temporary directory".into(),
+            ));
+        }
+
+        let output = Command::new(&canonical_exec_path)
             .output()
             .map_err(|e| CompilerError::Codegen(format!("Failed to execute program: {}", e)))?;
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Path Traversal / Arbitrary Execution. The Miri compiler dynamically builds user code in a temporary directory and executes it via `Command::new()`. Previously, it did not enforce that the resolved executable path actually remained within the generated temporary directory.
🎯 **Impact:** If an attacker can manipulate the intermediate generated code, compilation process, or pipeline structure to write the binary outside the temp directory (or point the executable path outside via symlinks/traversal characters), the compiler could execute an arbitrary file on the host system.
🔧 **Fix:** Added `canonicalize()` checks for both the temporary directory and the target executable path. A containment check `canonical_exec_path.starts_with(&canonical_temp_path)` is now enforced before running the binary. If it fails, a safe `CompilerError::Codegen` is returned.
✅ **Verification:** Ran `cargo clippy -- -D warnings`, `cargo fmt`, and the full test suite `cargo test` successfully.

---
*PR created automatically by Jules for task [12721119545196496127](https://jules.google.com/task/12721119545196496127) started by @slavikdev*