### PR TITLE
⚡ Bolt: Optimize trait method resolution to avoid string allocations

### DIFF
--- a/src/mir/lowering/dispatch.rs
+++ b/src/mir/lowering/dispatch.rs
@@ -152,17 +152,17 @@ fn resolve_in_trait_hierarchy(
     trait_name: &str,
     method_name: &str,
 ) -> Option<(String, MethodInfo)> {
-    let mut to_check = vec![trait_name.to_string()];
+    let mut to_check = vec![trait_name];
     let mut visited = std::collections::HashSet::new();
     while let Some(t_name) = to_check.pop() {
-        if !visited.insert(t_name.clone()) {
+        if !visited.insert(t_name) {
             continue;
         }
-        if let Some(TypeDefinition::Trait(td)) = type_defs.get(&t_name) {
+        if let Some(TypeDefinition::Trait(td)) = type_defs.get(t_name) {
             if let Some(method_info) = td.methods.get(method_name) {
-                return Some((t_name, method_info.clone()));
+                return Some((t_name.to_string(), method_info.clone()));
             }
-            to_check.extend(td.parent_traits.iter().cloned());
+            to_check.extend(td.parent_traits.iter().map(|s| s.as_str()));
         }
     }
     None
@@ -176,19 +176,19 @@ fn resolve_trait_default_method(
     trait_name: &str,
     method_name: &str,
 ) -> Option<(String, MethodInfo)> {
-    let mut to_check = vec![trait_name.to_string()];
+    let mut to_check = vec![trait_name];
     let mut visited = std::collections::HashSet::new();
     while let Some(t_name) = to_check.pop() {
-        if !visited.insert(t_name.clone()) {
+        if !visited.insert(t_name) {
             continue;
         }
-        if let Some(TypeDefinition::Trait(td)) = type_defs.get(&t_name) {
+        if let Some(TypeDefinition::Trait(td)) = type_defs.get(t_name) {
             if let Some(method_info) = td.methods.get(method_name) {
                 if !method_info.is_abstract {
-                    return Some((t_name, method_info.clone()));
+                    return Some((t_name.to_string(), method_info.clone()));
                 }
             }
-            to_check.extend(td.parent_traits.iter().cloned());
+            to_check.extend(td.parent_traits.iter().map(|s| s.as_str()));
         }
     }
     None


### PR DESCRIPTION
💡 **What:** 
Replaced `HashSet<String>` with `HashSet<&str>` and `Vec<String>` with `Vec<&str>` in the `resolve_in_trait_hierarchy` and `resolve_trait_default_method` functions in `src/mir/lowering/dispatch.rs`. This avoids allocating `String`s during the while loop traversal.

🎯 **Why:** 
These functions traverse the trait hierarchy to resolve inherited trait methods and default method implementations during MIR lowering. This is a hot path during method call lowering. Previously, every trait name added to the `visited` set or the `to_check` queue was deeply `.clone()`d from a `String` into another `String`. 

📊 **Impact:** 
Eliminates heap allocations for strings inside the `while let Some(...) = to_check.pop()` loops during trait method resolution.

🔬 **Measurement:** 
Run `cargo test` to verify correctness. The compile time for programs making heavy use of trait-typed receivers or deeply nested traits will have a modest reduction due to fewer memory allocations.

---
*PR created automatically by Jules for task [8044961735175759847](https://jules.google.com/task/8044961735175759847) started by @slavikdev*