### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Integer Overflow UB in Layout Calculation

### DIFF
--- a/src/runtime/core/src/list.rs
+++ b/src/runtime/core/src/list.rs
@@ -52,7 +52,12 @@ impl MiriList {
             return Self::new(elem_size);
         }
 
-        let layout = match Layout::from_size_align(capacity * elem_size, 8) {
+        let total_size = match capacity.checked_mul(elem_size) {
+            Some(size) => size,
+            None => return Self::new(elem_size),
+        };
+
+        let layout = match Layout::from_size_align(total_size, 8) {
             Ok(layout) => layout,
             Err(_) => return Self::new(elem_size),
         };
@@ -111,7 +116,11 @@ impl MiriList {
         let new_data = if self.data.is_null() {
             unsafe { alloc(layout) }
         } else {
-            match Layout::from_size_align(self.capacity * self.elem_size, 8) {
+            let old_size = self
+                .capacity
+                .checked_mul(self.elem_size)
+                .unwrap_or_else(|| std::process::abort());
+            match Layout::from_size_align(old_size, 8) {
                 Ok(old_layout) => unsafe { realloc(self.data, old_layout, new_size) },
                 Err(_) => std::process::abort(), // Abort safely rather than risking memory corruption
             }
@@ -270,9 +279,11 @@ impl MiriList {
 impl Drop for MiriList {
     fn drop(&mut self) {
         if !self.data.is_null() && self.capacity > 0 && self.elem_size > 0 {
-            if let Ok(layout) = Layout::from_size_align(self.capacity * self.elem_size, 8) {
-                unsafe {
-                    dealloc(self.data, layout);
+            if let Some(total_size) = self.capacity.checked_mul(self.elem_size) {
+                if let Ok(layout) = Layout::from_size_align(total_size, 8) {
+                    unsafe {
+                        dealloc(self.data, layout);
+                    }
                 }
             }
         }
@@ -402,7 +413,11 @@ pub mod ffi {
         if list.is_null() || capacity == 0 || elem_size == 0 {
             return list;
         }
-        let layout = match Layout::from_size_align(capacity * elem_size, 8) {
+        let total_size = match capacity.checked_mul(elem_size) {
+            Some(size) => size,
+            None => return list,
+        };
+        let layout = match Layout::from_size_align(total_size, 8) {
             Ok(l) => l,
             Err(_) => return list,
         };
@@ -661,7 +676,11 @@ pub mod ffi {
         // Free internal data buffer
         let list = &*ptr;
         if !list.data.is_null() && list.capacity > 0 && list.elem_size > 0 {
-            let layout = Layout::from_size_align(list.capacity * list.elem_size, 8)
+            let total_size = list
+                .capacity
+                .checked_mul(list.elem_size)
+                .unwrap_or_else(|| std::process::abort());
+            let layout = Layout::from_size_align(total_size, 8)
                 .unwrap_or_else(|_| std::process::abort());
             dealloc(list.data, layout);
         }

--- a/src/runtime/core/src/set.rs
+++ b/src/runtime/core/src/set.rs
@@ -176,7 +176,10 @@ impl MiriSet {
             dealloc(states, states_layout);
         }
         if !data.is_null() && capacity > 0 && elem_size > 0 {
-            let data_layout = Layout::from_size_align(capacity * elem_size, 8)
+            let total_size = capacity
+                .checked_mul(elem_size)
+                .unwrap_or_else(|| std::process::abort());
+            let data_layout = Layout::from_size_align(total_size, 8)
                 .unwrap_or_else(|_| std::process::abort());
             dealloc(data, data_layout);
         }


### PR DESCRIPTION
Replaced standard multiplication with `checked_mul` during heap buffer allocation and deallocation across core `MiriList` and `MiriSet` types. Prevents Integer Overflows during capacity calculation that wrap around and cause arbitrary memory corruption (Heap Buffer Overflows) or Undefined Behavior. Fallbacks to process termination (`abort`) when allocation geometries are invalid to fail safely.

---
*PR created automatically by Jules for task [3376016615831281000](https://jules.google.com/task/3376016615831281000) started by @slavikdev*