### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Integer Overflow Heap Buffer Overflow in Collections

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,7 @@
 **Vulnerability:** Potential Integer Overflow during capacity calculations in `free_buffers` of `src/runtime/core/src/map.rs` where `capacity * key_size` is calculated.
 **Learning:** Raw memory deallocation operations using `Layout::from_size_align` can accept incorrect wrapped-around integer values resulting in Undefined Behavior (UB) if the size overflows `usize`.
 **Prevention:** Use `checked_mul` (e.g. `capacity.checked_mul(key_size)`) to detect overflow during manual memory management operations.
+## 2024-05-27 - [Heap Buffer Overflow via Integer Overflow in Collections]
+**Vulnerability:** A potential Integer Overflow during capacity calculations in `src/runtime/core/src/map.rs` and `src/runtime/core/src/set.rs` when multiplying capacity with key/value size (`capacity * key_size`).
+**Learning:** Raw memory allocation and deallocation operations using `Layout::from_size_align` can accept incorrect wrapped-around integer values, resulting in Heap Buffer Overflows if the allocated layout is smaller than the requested bounds, or Undefined Behavior during deallocation.
+**Prevention:** Use `checked_mul` (e.g., `capacity.checked_mul(key_size)?`) to detect overflow during manual memory management operations, aborting safely if returning an error isn't feasible.

--- a/src/runtime/core/src/map.rs
+++ b/src/runtime/core/src/map.rs
@@ -172,9 +172,9 @@ impl MiriMap {
             return None;
         }
         let states_layout = Layout::from_size_align(capacity, 1).ok()?;
-        let keys_layout = Layout::from_size_align(capacity * key_size, 8).ok()?;
+        let keys_layout = Layout::from_size_align(capacity.checked_mul(key_size)?, 8).ok()?;
         // value_size can be 0 for value-less maps (unlikely but safe)
-        let val_total = capacity * value_size.max(1);
+        let val_total = capacity.checked_mul(value_size.max(1))?;
         let values_layout = Layout::from_size_align(val_total, 8).ok()?;
 
         let states = alloc_zeroed(states_layout);
@@ -234,7 +234,7 @@ impl MiriMap {
         let new_capacity = if self.capacity == 0 {
             INITIAL_CAPACITY
         } else {
-            self.capacity * 2
+            self.capacity.checked_mul(2).unwrap_or_else(|| std::process::abort())
         };
 
         let Some((new_states, new_keys, new_values)) =

--- a/src/runtime/core/src/set.rs
+++ b/src/runtime/core/src/set.rs
@@ -148,7 +148,7 @@ impl MiriSet {
         let old_data = self.data;
         let old_capacity = self.capacity;
 
-        let new_capacity = old_capacity * 2;
+        let new_capacity = old_capacity.checked_mul(2).unwrap_or_else(|| std::process::abort());
         self.alloc_tables(new_capacity);
         self.len = 0;
 
@@ -176,8 +176,11 @@ impl MiriSet {
             dealloc(states, states_layout);
         }
         if !data.is_null() && capacity > 0 && elem_size > 0 {
-            let data_layout = Layout::from_size_align(capacity * elem_size, 8)
-                .unwrap_or_else(|_| std::process::abort());
+            let data_layout = Layout::from_size_align(
+                capacity.checked_mul(elem_size).unwrap_or_else(|| std::process::abort()),
+                8,
+            )
+            .unwrap_or_else(|_| std::process::abort());
             dealloc(data, data_layout);
         }
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Integer overflow vulnerability during capacity calculations (`capacity * size`) in `MiriMap` and `MiriSet`.
🎯 **Impact:** If an overflow occurs, `Layout::from_size_align` could allocate a much smaller buffer than requested, leading to a Heap Buffer Overflow (Undefined Behavior). This could result in memory corruption or arbitrary code execution.
🔧 **Fix:** Replaced standard multiplication with `checked_mul` in `alloc_tables` and `grow` methods across `src/runtime/core/src/map.rs` and `src/runtime/core/src/set.rs`. Infallible operations now abort safely using `std::process::abort()` instead of continuing with corrupted layout metadata.
✅ **Verification:** Verified by running `cargo build --release` in `src/runtime/core`, `cargo clippy -- -D warnings`, `cargo fmt`, and full Miri tests (`cargo test`) locally. Changes were thoroughly reviewed and verified via git diff.

---
*PR created automatically by Jules for task [18102728441336536291](https://jules.google.com/task/18102728441336536291) started by @slavikdev*