### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in executable invocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** Potential Integer Overflow during capacity calculations in `free_buffers` of `src/runtime/core/src/map.rs` where `capacity * key_size` is calculated.
 **Learning:** Raw memory deallocation operations using `Layout::from_size_align` can accept incorrect wrapped-around integer values resulting in Undefined Behavior (UB) if the size overflows `usize`.
 **Prevention:** Use `checked_mul` (e.g. `capacity.checked_mul(key_size)`) to detect overflow during manual memory management operations.
+
+## 2024-05-27 - [Path Traversal in Temp Executable Invocation]
+**Vulnerability:** `Command::new` was invoking an executable path formed by appending "program" to a temporary directory without canonicalizing or checking bounds.
+**Learning:** Even when using seemingly safe temporary directories, paths must be strictly checked. If an attacker manages to construct a malicious path string or creates symbolic links pointing outside the intended directory, `Command::new` might execute arbitrary binaries instead of the compiled program.
+**Prevention:** Both the temporary directory and the final executable path must be canonicalized, followed by a strict containment check (`canonical_executable.starts_with(&canonical_temp_dir)`) before passing the path to `Command::new`.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -399,14 +399,13 @@ impl Pipeline {
 
         self.build(source, &build_opts)?;
 
-        let canonical_temp_dir = temp_dir
-            .path()
-            .canonicalize()
-            .map_err(|e| CompilerError::Codegen(format!("Failed to canonicalize temp dir: {}", e)))?;
+        let canonical_temp_dir = temp_dir.path().canonicalize().map_err(|e| {
+            CompilerError::Codegen(format!("Failed to canonicalize temp dir: {}", e))
+        })?;
 
-        let canonical_executable_path = executable_path
-            .canonicalize()
-            .map_err(|e| CompilerError::Codegen(format!("Failed to canonicalize executable path: {}", e)))?;
+        let canonical_executable_path = executable_path.canonicalize().map_err(|e| {
+            CompilerError::Codegen(format!("Failed to canonicalize executable path: {}", e))
+        })?;
 
         // Security check: Ensure the executable is strictly within the expected temporary directory
         // to prevent symlink attacks and path traversal

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -399,7 +399,24 @@ impl Pipeline {
 
         self.build(source, &build_opts)?;
 
-        let output = Command::new(&executable_path)
+        let canonical_temp_dir = temp_dir
+            .path()
+            .canonicalize()
+            .map_err(|e| CompilerError::Codegen(format!("Failed to canonicalize temp dir: {}", e)))?;
+
+        let canonical_executable_path = executable_path
+            .canonicalize()
+            .map_err(|e| CompilerError::Codegen(format!("Failed to canonicalize executable path: {}", e)))?;
+
+        // Security check: Ensure the executable is strictly within the expected temporary directory
+        // to prevent symlink attacks and path traversal
+        if !canonical_executable_path.starts_with(&canonical_temp_dir) {
+            return Err(CompilerError::Codegen(
+                "Security violation: executable path escapes temporary directory".to_string(),
+            ));
+        }
+
+        let output = Command::new(&canonical_executable_path)
             .output()
             .map_err(|e| CompilerError::Codegen(format!("Failed to execute program: {}", e)))?;
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The compiler invoked the dynamically built executable from a temporary directory without checking bounds. This could allow execution of arbitrary binaries via symlink attacks or path traversal in the temporary directory.
🎯 **Impact:** Potential arbitrary command execution if an attacker manages to manipulate paths or create symbolic links in the `tempdir`.
🔧 **Fix:** Canonicalize both the temporary directory and the generated executable path, and perform a strict containment check (`starts_with`) before invoking `Command::new()`.
✅ **Verification:** Verified that tests pass via `cargo test` and the lints are clean via `cargo clippy`.

---
*PR created automatically by Jules for task [16638098456988226323](https://jules.google.com/task/16638098456988226323) started by @slavikdev*