### PR TITLE
⚡ Bolt: Replace format! with String::with_capacity in Cranelift symbol generation

### DIFF
--- a/src/codegen/cranelift/translate_rvalue.rs
+++ b/src/codegen/cranelift/translate_rvalue.rs
@@ -482,7 +482,9 @@ impl<'a> FunctionTranslator<'a> {
                     // For vtable-bearing classes, store vtable pointer at offset 0 of payload.
                     if let Some(ref class_name) = vtable_header {
                         use cranelift_module::Module;
-                        let vtable_sym = format!("__vtable_{}", class_name);
+                        let mut vtable_sym = String::with_capacity(9 + class_name.len());
+                        vtable_sym.push_str("__vtable_");
+                        vtable_sym.push_str(class_name);
                         let vtable_data_id = ctx
                             .module
                             .declare_data(

--- a/src/codegen/cranelift/translator.rs
+++ b/src/codegen/cranelift/translator.rs
@@ -1637,7 +1637,9 @@ impl<'a> FunctionTranslator<'a> {
         ptr: Value,
         ptr_type: cranelift_codegen::ir::Type,
     ) -> Result<(), String> {
-        let thunk_name = format!("__drop_{}", type_name);
+        let mut thunk_name = String::with_capacity(7 + type_name.len());
+        thunk_name.push_str("__drop_");
+        thunk_name.push_str(type_name);
         let mut sig = Signature::new(builder.func.signature.call_conv);
         sig.params.push(AbiParam::new(ptr_type));
         let func_id = ctx
@@ -1671,7 +1673,9 @@ impl<'a> FunctionTranslator<'a> {
         let ptr_size = ptr_type.bytes() as i64;
 
         // Declare the function with Export linkage so other functions can call it.
-        let func_name = format!("__drop_{}", type_name);
+        let mut func_name = String::with_capacity(7 + type_name.len());
+        func_name.push_str("__drop_");
+        func_name.push_str(type_name);
         let mut sig = Signature::new(call_conv);
         sig.params.push(AbiParam::new(ptr_type));
         let func_id = module
@@ -1921,7 +1925,9 @@ impl<'a> FunctionTranslator<'a> {
             let vtable_size = (num_slots * ptr_size as usize) as u32;
 
             // Declare the vtable data as Export (may already be declared as Import by constructors).
-            let vtable_sym = format!("__vtable_{}", class_name);
+            let mut vtable_sym = String::with_capacity(9 + class_name.len());
+            vtable_sym.push_str("__vtable_");
+            vtable_sym.push_str(class_name);
             let vtable_data_id = module
                 .declare_data(&vtable_sym, Linkage::Export, false, false)
                 .map_err(|e| format!("Failed to declare vtable {}: {}", vtable_sym, e))?;


### PR DESCRIPTION
**💡 What:**
Replaced `format!("__drop_{}", type_name)` and `format!("__vtable_{}", class_name)` with manual string allocations using `String::with_capacity` and `push_str` in `src/codegen/cranelift/translator.rs` and `src/codegen/cranelift/translate_rvalue.rs`.

**🎯 Why:**
The `format!` macro incurs runtime parsing overhead and often performs hidden intermediate allocations. In the compiler backend, generating these mangled function names (`__drop_` and `__vtable_`) is done repeatedly for every type that needs to be dropped or every class that has virtual methods. Pre-calculating the exact required capacity and pushing substrings directly skips this overhead and improves codegen performance in hot paths.

**📊 Impact:**
Reduces heap allocations and eliminates format parsing overhead in the Cranelift code generation phase when compiling Miri code with classes or dropped types.

**🔬 Measurement:**
Can be verified via profiling or microbenchmarks on large Miri source files that generate many drop thunks and vtables. The generated Cranelift IR remains identical. Verified through passing all compiler tests and matching test output.

---
*PR created automatically by Jules for task [5600226086563604033](https://jules.google.com/task/5600226086563604033) started by @slavikdev*