### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in executable invocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** Potential Integer Overflow during capacity calculations in `free_buffers` of `src/runtime/core/src/map.rs` where `capacity * key_size` is calculated.
 **Learning:** Raw memory deallocation operations using `Layout::from_size_align` can accept incorrect wrapped-around integer values resulting in Undefined Behavior (UB) if the size overflows `usize`.
 **Prevention:** Use `checked_mul` (e.g. `capacity.checked_mul(key_size)`) to detect overflow during manual memory management operations.
+
+## 2024-05-27 - [Symlink/Path Traversal in Temp Execution]
+**Vulnerability:** The compiler invoked built executables from a temp directory via `Command::new(executable_path)`. If `executable_path` was a relative path navigating outside the temp dir, or a symlink to another host binary, it could lead to arbitrary command execution on the host machine during the build phase.
+**Learning:** `Command::new` follows paths naively. When executing artifacts generated from untrusted source in a temporary directory, strict containment checks must be enforced.
+**Prevention:** Always use `canonicalize()` to resolve both the temporary directory and the target executable path, and perform a strict containment check (`canonical_exe.starts_with(&canonical_temp)`) to ensure the executable is genuinely contained within the safe environment before execution.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -399,7 +399,13 @@ impl Pipeline {
 
         self.build(source, &build_opts)?;
 
-        let output = Command::new(&executable_path)
+        let canonical_temp = temp_dir.path().canonicalize().map_err(|e| CompilerError::Codegen(format!("Failed to canonicalize temp dir: {}", e)))?;
+        let canonical_exe = executable_path.canonicalize().map_err(|e| CompilerError::Codegen(format!("Failed to canonicalize executable path: {}", e)))?;
+        if !canonical_exe.starts_with(&canonical_temp) {
+            return Err(CompilerError::Codegen("Access denied: executable path is outside of temp directory".to_string()));
+        }
+
+        let output = Command::new(&canonical_exe)
             .output()
             .map_err(|e| CompilerError::Codegen(format!("Failed to execute program: {}", e)))?;
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal / symlink vulnerability in executable invocation within `src/pipeline.rs`.
🎯 **Impact:** If `executable_path` could be manipulated (e.g., via malicious module configuration or symlinks generated during build), `Command::new` would execute arbitrary host binaries outside the intended temporary directory sandbox.
🔧 **Fix:** Both the temporary directory and the final executable path are now canonicalized. A strict containment check (`starts_with`) ensures the resolved executable path genuinely resides within the temporary directory. If it escapes, it returns an access denied error.
✅ **Verification:** Verified by inspecting the patch and running `cargo test` and `cargo test --test mod` to ensure compilation pipelines execute safely under normal bounds. Added learning to Sentinel's journal.

---
*PR created automatically by Jules for task [7850232743218709572](https://jules.google.com/task/7850232743218709572) started by @slavikdev*