### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix integer overflow UB in set.rs layout calc

### DIFF
--- a/src/runtime/core/src/set.rs
+++ b/src/runtime/core/src/set.rs
@@ -176,7 +176,10 @@ impl MiriSet {
             dealloc(states, states_layout);
         }
         if !data.is_null() && capacity > 0 && elem_size > 0 {
-            let data_layout = Layout::from_size_align(capacity * elem_size, 8)
+            let data_size = capacity
+                .checked_mul(elem_size)
+                .unwrap_or_else(|| std::process::abort());
+            let data_layout = Layout::from_size_align(data_size, 8)
                 .unwrap_or_else(|_| std::process::abort());
             dealloc(data, data_layout);
         }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Integer overflow in capacity calculation (`capacity * elem_size`) in MiriSet `free_tables`.
🎯 Impact: An attacker could potentially pass crafted data triggering an overflow causing `dealloc` to be called with a vastly smaller incorrect layout size. This causes Undefined Behavior, potentially resulting in exploitable memory corruption during teardown/resizing.
🔧 Fix: Replaced standard multiplication with `checked_mul`. If overflow occurs, execution is safely halted using `std::process::abort()`.
✅ Verification: Ran full `cargo test` suite over `src/runtime/core` with 0 failures and 0 warnings. Verified that the fix accurately mimics existing patterns used in `map.rs` in this codebase.

---
*PR created automatically by Jules for task [6524009188413893773](https://jules.google.com/task/6524009188413893773) started by @slavikdev*