### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix integer overflow in map memory allocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,6 @@
 **Vulnerability:** Potential Integer Overflow during capacity calculations in `free_buffers` of `src/runtime/core/src/map.rs` where `capacity * key_size` is calculated.
 **Learning:** Raw memory deallocation operations using `Layout::from_size_align` can accept incorrect wrapped-around integer values resulting in Undefined Behavior (UB) if the size overflows `usize`.
 **Prevention:** Use `checked_mul` (e.g. `capacity.checked_mul(key_size)`) to detect overflow during manual memory management operations.
+**Vulnerability:** Unchecked multiplication leading to integer overflow in manual memory management for runtime collections (`map.rs`).
+**Learning:** In runtime collections implemented in Rust (`map.rs`), calculating total sizes for allocations (e.g., `capacity * key_size` or `capacity * value_size.max(1)`) without checking for integer overflows can result in allocating an undersized buffer. This can be exploited by an attacker providing a large capacity or size, causing a Heap Buffer Overflow (OOM DoS or RCE).
+**Prevention:** Always use safe arithmetic methods like `.checked_mul()` before allocating memory via `Layout::from_size_align` to guarantee accurate size computation and prevent undersized heap buffers.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+🚨 Severity: CRITICAL
+💡 Vulnerability: Integer overflow in map allocation size calculations (`capacity * key_size` and `capacity * value_size.max(1)`).
+🎯 Impact: Allows an attacker to trigger an integer overflow, allocating an undersized buffer and causing a Heap Buffer Overflow (OOM DoS or RCE).
+🔧 Fix: Use `.checked_mul()` for size calculations and return `None` gracefully on overflow.
+✅ Verification: Covered by existing `cargo test` in `src/runtime/core`.

--- a/src/runtime/core/src/map.rs
+++ b/src/runtime/core/src/map.rs
@@ -172,9 +172,12 @@ impl MiriMap {
             return None;
         }
         let states_layout = Layout::from_size_align(capacity, 1).ok()?;
-        let keys_layout = Layout::from_size_align(capacity * key_size, 8).ok()?;
+
+        let keys_total = capacity.checked_mul(key_size)?;
+        let keys_layout = Layout::from_size_align(keys_total, 8).ok()?;
+
         // value_size can be 0 for value-less maps (unlikely but safe)
-        let val_total = capacity * value_size.max(1);
+        let val_total = capacity.checked_mul(value_size.max(1))?;
         let values_layout = Layout::from_size_align(val_total, 8).ok()?;
 
         let states = alloc_zeroed(states_layout);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Integer overflow in map allocation size calculations (`capacity * key_size` and `capacity * value_size.max(1)`).
🎯 Impact: Allows an attacker to trigger an integer overflow, allocating an undersized buffer and causing a Heap Buffer Overflow (OOM DoS or RCE).
🔧 Fix: Use `.checked_mul()` for size calculations and return `None` gracefully on overflow.
✅ Verification: Covered by existing `cargo test` in `src/runtime/core`.

---
*PR created automatically by Jules for task [16355468469669987483](https://jules.google.com/task/16355468469669987483) started by @slavikdev*