### PR TITLE
🔒 Remove unsafe environment variable modification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,31 +14,32 @@ use miri::pipeline::{BuildOptions, Pipeline};
 pub fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Propagate --verify-mir as an environment variable so the pipeline can
-    // check it without requiring every call site to thread a flag through.
-    if cli.verify_mir {
-        // SAFETY: single-threaded at this point (before the pipeline starts).
-        unsafe {
-            std::env::set_var("MIRI_VERIFY_MIR", "1");
-        }
-    }
-
     match cli.command {
         Some(command) => match command {
-            Commands::Run { path, program_args } => run_file(path, program_args, cli.verbose),
+            Commands::Run { path, program_args } => {
+                run_file(path, program_args, cli.verbose, cli.verify_mir)
+            }
             Commands::Build {
                 path,
                 out,
                 release,
                 opt_level,
                 cpu_backend,
-            } => build_file(path, out, release, opt_level, cpu_backend, cli.verbose),
-            Commands::Check { path } => check_file(path, cli.verbose),
+            } => build_file(
+                path,
+                out,
+                release,
+                opt_level,
+                cpu_backend,
+                cli.verbose,
+                cli.verify_mir,
+            ),
+            Commands::Check { path } => check_file(path, cli.verbose, cli.verify_mir),
             Commands::Test {
                 filter,
                 format,
                 dir,
-            } => run_tests(filter, format, dir, cli.verbose),
+            } => run_tests(filter, format, dir, cli.verbose, cli.verify_mir),
         },
         None => {
             Cli::command().print_help()?;
@@ -47,11 +48,16 @@ pub fn main() -> Result<()> {
     }
 }
 
-fn run_file(path: PathBuf, _program_args: Vec<String>, _verbose: u8) -> Result<()> {
+fn run_file(
+    path: PathBuf,
+    _program_args: Vec<String>,
+    _verbose: u8,
+    verify_mir: bool,
+) -> Result<()> {
     let source = fs::read_to_string(&path)
         .with_context(|| format!("Failed to read file: {}", path.display()))?;
 
-    let mut pipeline = Pipeline::new();
+    let mut pipeline = Pipeline::new().with_verify_mir(verify_mir);
     // Canonicalize first so that a bare filename like "main.mi" resolves to an
     // absolute path whose parent is the working directory, not an empty path.
     let abs_path = path.canonicalize().unwrap_or_else(|_| path.clone());
@@ -81,11 +87,12 @@ fn build_file(
     opt_level: u8,
     cpu_backend: CpuBackend,
     _verbose: u8,
+    verify_mir: bool,
 ) -> Result<()> {
     let source = fs::read_to_string(&path)
         .with_context(|| format!("Failed to read file: {}", path.display()))?;
 
-    let mut pipeline = Pipeline::new();
+    let mut pipeline = Pipeline::new().with_verify_mir(verify_mir);
     let abs_path = path.canonicalize().unwrap_or_else(|_| path.clone());
     if let Some(dir) = abs_path.parent() {
         pipeline = pipeline.with_source_dir(dir.to_path_buf());
@@ -110,11 +117,11 @@ fn build_file(
     }
 }
 
-fn check_file(path: PathBuf, _verbose: u8) -> Result<()> {
+fn check_file(path: PathBuf, _verbose: u8, verify_mir: bool) -> Result<()> {
     let source = fs::read_to_string(&path)
         .with_context(|| format!("Failed to read file: {}", path.display()))?;
 
-    let mut pipeline = Pipeline::new();
+    let mut pipeline = Pipeline::new().with_verify_mir(verify_mir);
     let abs_path = path.canonicalize().unwrap_or_else(|_| path.clone());
     if let Some(dir) = abs_path.parent() {
         pipeline = pipeline.with_source_dir(dir.to_path_buf());
@@ -165,8 +172,14 @@ struct TestSummary {
     results: Vec<TestResult>,
 }
 
-fn run_tests(filter: Option<String>, format: TestFormat, dir: PathBuf, _verbose: u8) -> Result<()> {
-    let pipeline = Pipeline::new();
+fn run_tests(
+    filter: Option<String>,
+    format: TestFormat,
+    dir: PathBuf,
+    _verbose: u8,
+    verify_mir: bool,
+) -> Result<()> {
+    let pipeline = Pipeline::new().with_verify_mir(verify_mir);
     let mut results = Vec::new();
 
     let test_files = WalkDir::new(dir)

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -288,6 +288,8 @@ pub struct Pipeline {
     /// Absolute path of the entry-point source file, used so that *all*
     /// errors (not just those from imported modules) include a file location.
     source_path: Option<String>,
+    /// Whether to run the MIR verification pass after RC insertion.
+    verify_mir: bool,
 }
 
 impl Default for Pipeline {
@@ -301,6 +303,7 @@ impl Pipeline {
         Self {
             source_dir: None,
             source_path: None,
+            verify_mir: false,
         }
     }
 
@@ -315,6 +318,12 @@ impl Pipeline {
     /// source file.  This enables file-path display in all error messages.
     pub fn with_source_path(mut self, path: String) -> Self {
         self.source_path = Some(path);
+        self
+    }
+
+    /// Configure whether to run the MIR verification pass after RC insertion.
+    pub fn with_verify_mir(mut self, verify: bool) -> Self {
+        self.verify_mir = verify;
         self
     }
 
@@ -1033,9 +1042,8 @@ impl Pipeline {
 
         // Optional MIR verification pass: check RC invariants after Perceus.
         // Enabled by setting the MIRI_VERIFY_MIR environment variable to any
-        // non-empty value, or by passing --verify-mir on the CLI (which sets
-        // this variable before invoking the pipeline).
-        if std::env::var("MIRI_VERIFY_MIR").is_ok() {
+        // non-empty value, or by configuring it on the Pipeline instance.
+        if self.verify_mir || std::env::var("MIRI_VERIFY_MIR").is_ok() {
             let mut all_violations = Vec::new();
             for (name, body) in &bodies {
                 let violations = mir::verify::verify_body(body);


### PR DESCRIPTION
🎯 **What:** This PR removes the unsafe usage of `std::env::set_var` in `src/main.rs` used to enable MIR verification.

⚠️ **Risk:** `std::env::set_var` is inherently unsound in multi-threaded Rust programs (and marked `unsafe` since Rust 1.81). Calling it can lead to data races and segmentation faults if other threads concurrently read or write the environment. While currently used at the start of `main`, this pattern is fragile and violates security best practices for robust compiler infrastructure.

🛡️ **Solution:** 
- Modified the `Pipeline` struct in `src/pipeline.rs` to include a `verify_mir` flag.
- Added a `with_verify_mir` builder method to `Pipeline`.
- Updated `Pipeline::lower_to_mir` to check both its internal flag and the `MIRI_VERIFY_MIR` environment variable (read-only).
- Updated `src/main.rs` to remove the `unsafe { std::env::set_var(...) }` block and instead pass the configuration through the `Pipeline` instances created for `run`, `build`, `check`, and `test` commands.

---
*PR created automatically by Jules for task [1553980038380738443](https://jules.google.com/task/1553980038380738443) started by @slavikdev*