### PR TITLE
⚡ Bolt: Optimize string allocations in vtable generation

### DIFF
--- a/src/codegen/cranelift/translator.rs
+++ b/src/codegen/cranelift/translator.rs
@@ -1911,13 +1911,13 @@ impl<'a> FunctionTranslator<'a> {
             // most-derived abstract class wins (though in practice abstract classes
             // don't redeclare each other's methods).
             let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-            let mut vtable_methods: Vec<String> = Vec::new();
+            let mut vtable_methods: Vec<&str> = Vec::new();
             for ancestor in abstract_chain.iter().rev() {
                 if let Some(TypeDefinition::Class(cd)) = type_definitions.get(*ancestor) {
                     for (method_name, method_info) in &cd.methods {
                         if !method_info.is_constructor && !seen.contains(method_name.as_str()) {
                             seen.insert(method_name.as_str());
-                            vtable_methods.push(method_name.clone());
+                            vtable_methods.push(method_name.as_str());
                         }
                     }
                 }
@@ -1935,7 +1935,7 @@ impl<'a> FunctionTranslator<'a> {
                         for m in trait_methods {
                             if !seen.contains(m) {
                                 seen.insert(m);
-                                vtable_methods.push(m.to_string());
+                                vtable_methods.push(m);
                             }
                         }
                     }

--- a/src/type_checker/context.rs
+++ b/src/type_checker/context.rs
@@ -260,20 +260,20 @@ pub fn vtable_slot_index(
     // Collect methods from all abstract ancestors (topmost last in chain,
     // so we reverse to process topmost first), deduplicated, alphabetically sorted.
     let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-    let mut all_methods: Vec<String> = Vec::new();
+    let mut all_methods: Vec<&str> = Vec::new();
     for ancestor in abstract_chain.iter().rev() {
         if let Some(TypeDefinition::Class(cd)) = type_defs.get(*ancestor) {
             for (name, m) in &cd.methods {
                 if !m.is_constructor && !seen.contains(name.as_str()) {
                     seen.insert(name.as_str());
-                    all_methods.push(name.clone());
+                    all_methods.push(name.as_str());
                 }
             }
         }
     }
     all_methods.sort();
 
-    all_methods.iter().position(|n| n == method_name)
+    all_methods.iter().position(|n| *n == method_name)
 }
 
 /// Collect all non-constructor method names from a trait and its parent traits.


### PR DESCRIPTION
💡 **What**: Replaced `Vec<String>` with `Vec<&str>` in `src/type_checker/context.rs` (`vtable_slot_index`) and `src/codegen/cranelift/translator.rs` (`generate_vtables`).
🎯 **Why**: To eliminate unnecessary intermediate heap allocations and string cloning when computing vtable slots and traversing inheritance hierarchies for method resolution during Cranelift code generation.
📊 **Impact**: Reduces heap pressure and slightly improves compilation speed by avoiding `.clone()` and `.to_string()` in hot loops within the compiler backend.
🔬 **Measurement**: Validated correctness by running the full Miri test suite (`cargo test`) to ensure all assertions regarding traits and inheritance remain successful, and `cargo clippy -- -D warnings` to verify no borrow checker/lifetime issues were introduced.

---
*PR created automatically by Jules for task [6873104682216727326](https://jules.google.com/task/6873104682216727326) started by @slavikdev*