### PR TITLE
⚡ Bolt: [performance improvement] Eliminate string allocations in vtable method collection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2024-05-25 - Prevent Intermediate String Allocations via Format Macro
 **Learning:** During Cranelift code generation for `thunk_name` (`__drop_{}`), `vtable_sym` (`__vtable_{}`) and `struct_symbol` (`{}_struct`), `format!` macros parsed at runtime, which allocated strings needlessly and was identified as a hot path bottleneck.
 **Action:** Replaced `format!` macros with manual string allocations using `String::with_capacity` and sequential `push_str()` additions. When creating performance-oriented code, calculating the exact required buffer capacity initially prevents heap reallocations.
+
+## 2024-05-26 - [Eliminate String Allocations in VTable Collection]
+**Learning:** During vtable method collection in both the type checker and Cranelift translator, `String` cloning (`method_name.clone()`, `m.to_string()`) was used when building a list of method names for layout generation and lookup. This resulted in unnecessary heap allocations when these string representations were only needed for transient iteration or index finding.
+**Action:** Use `&str` instead of `String` when collecting method names into transient collections like `Vec<&str>` during vtable generation and lookup. This completely bypasses the heap allocation overhead without compromising correctness or safety.

--- a/src/codegen/cranelift/translator.rs
+++ b/src/codegen/cranelift/translator.rs
@@ -1911,13 +1911,13 @@ impl<'a> FunctionTranslator<'a> {
             // most-derived abstract class wins (though in practice abstract classes
             // don't redeclare each other's methods).
             let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-            let mut vtable_methods: Vec<String> = Vec::new();
+            let mut vtable_methods: Vec<&str> = Vec::new();
             for ancestor in abstract_chain.iter().rev() {
                 if let Some(TypeDefinition::Class(cd)) = type_definitions.get(*ancestor) {
                     for (method_name, method_info) in &cd.methods {
                         if !method_info.is_constructor && !seen.contains(method_name.as_str()) {
                             seen.insert(method_name.as_str());
-                            vtable_methods.push(method_name.clone());
+                            vtable_methods.push(method_name.as_str());
                         }
                     }
                 }
@@ -1935,7 +1935,7 @@ impl<'a> FunctionTranslator<'a> {
                         for m in trait_methods {
                             if !seen.contains(m) {
                                 seen.insert(m);
-                                vtable_methods.push(m.to_string());
+                                vtable_methods.push(m);
                             }
                         }
                     }

--- a/src/type_checker/context.rs
+++ b/src/type_checker/context.rs
@@ -260,20 +260,20 @@ pub fn vtable_slot_index(
     // Collect methods from all abstract ancestors (topmost last in chain,
     // so we reverse to process topmost first), deduplicated, alphabetically sorted.
     let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-    let mut all_methods: Vec<String> = Vec::new();
+    let mut all_methods: Vec<&str> = Vec::new();
     for ancestor in abstract_chain.iter().rev() {
         if let Some(TypeDefinition::Class(cd)) = type_defs.get(*ancestor) {
             for (name, m) in &cd.methods {
                 if !m.is_constructor && !seen.contains(name.as_str()) {
                     seen.insert(name.as_str());
-                    all_methods.push(name.clone());
+                    all_methods.push(name.as_str());
                 }
             }
         }
     }
     all_methods.sort();
 
-    all_methods.iter().position(|n| n == method_name)
+    all_methods.iter().position(|&n| n == method_name)
 }
 
 /// Collect all non-constructor method names from a trait and its parent traits.


### PR DESCRIPTION
💡 **What:** Replaces `Vec<String>` with `Vec<&str>` when collecting abstract methods in both `type_checker` and `cranelift` translator loops.
🎯 **Why:** Previously, generating the vtable layouts required allocating multiple owned Strings (`name.clone()`, `m.to_string()`), which adds significant overhead when method names are only needed for transient layout ordering or lookup.
📊 **Impact:** Reduces unnecessary heap allocations during vtable layout construction, optimizing type checking and code generation times.
🔬 **Measurement:** Compile time reductions and benchmark metrics against Cranelift AST to IR translation.

---
*PR created automatically by Jules for task [5381131003344586755](https://jules.google.com/task/5381131003344586755) started by @slavikdev*