### PR TITLE
Normalize the canonical work-dir root before its nested form

### DIFF
--- a/evals/results/baseline.json
+++ b/evals/results/baseline.json
@@ -10,7 +10,7 @@
     "task": "b",
     "success": true,
     "invocations": 6,
-    "bytes_read": 2330,
+    "bytes_read": 2290,
     "bytes_written": 74
   },
   {
@@ -24,14 +24,14 @@
     "task": "d",
     "success": true,
     "invocations": 4,
-    "bytes_read": 1401,
+    "bytes_read": 1361,
     "bytes_written": 85
   },
   {
     "task": "e",
     "success": true,
     "invocations": 5,
-    "bytes_read": 2030,
+    "bytes_read": 2022,
     "bytes_written": 118
   },
   {

--- a/evals/results/baseline.md
+++ b/evals/results/baseline.md
@@ -17,8 +17,8 @@ this file on every run. The harness prints it to stdout instead.
 | Task | What it does | Success | Invocations | Bytes read | Bytes written |
 |------|--------------|---------|-------------|------------|---------------|
 | a | build hello world from an empty directory | yes | 2 | 131 | 39 |
-| b | repair a broken program using check, explain and fix | yes | 6 | 2330 | 74 |
+| b | repair a broken program using check, explain and fix | yes | 6 | 2290 | 74 |
 | c | add a function and its test | yes | 4 | 702 | 199 |
-| d | extend a program with a stdlib module | yes | 4 | 1401 | 85 |
-| e | recover from a capability rejection | yes | 5 | 2030 | 118 |
+| d | extend a program with a stdlib module | yes | 4 | 1361 | 85 |
+| e | recover from a capability rejection | yes | 5 | 2022 | 118 |
 | f | make a failing test pass | yes | 4 | 631 | 128 |

--- a/tests/evals/mod.rs
+++ b/tests/evals/mod.rs
@@ -170,14 +170,28 @@ fn normalize_output(output: &str, work_dir: &Path) -> String {
             roots.push(canonical);
         }
     }
-    for root in roots {
+
+    normalize_paths(&result, &roots)
+}
+
+/// Rewrite every occurrence of `roots` in `text` to a fixed stand-in.
+///
+/// The longest root is rewritten first. One root can contain another — macOS
+/// canonicalizes `/var/...` to `/private/var/...` — and rewriting the shorter
+/// one first would consume its tail and strand the `/private` prefix, leaving
+/// the byte count carrying a platform-dependent eight characters per path.
+fn normalize_paths(text: &str, roots: &[PathBuf]) -> String {
+    let mut ordered: Vec<&PathBuf> = roots.iter().collect();
+    ordered.sort_by_key(|root| std::cmp::Reverse(root.as_os_str().len()));
+
+    let mut result = text.to_string();
+    for root in ordered {
         if let Some(text) = root.to_str() {
             let re = regex::Regex::new(&regex::escape(text))
                 .expect("an escaped literal path must compile as a pattern");
             result = re.replace_all(&result, ".").into_owned();
         }
     }
-
     result
 }
 
@@ -860,6 +874,28 @@ mod tests {
         let normalized = normalize_output(raw, work);
         assert!(normalized.contains(r#""durationMs":0"#));
         assert!(normalized.contains(r#""path":"./program.mi""#));
+    }
+
+    #[test]
+    fn test_a_root_nested_in_another_root_is_fully_rewritten() {
+        // macOS resolves a temporary directory through /private, so the
+        // harness holds /var/... while the compiler reports /private/var/...
+        // The shorter root is a substring of the longer one; rewriting it
+        // first would strip the tail and strand the /private prefix.
+        let nested = PathBuf::from("/var/t/eval");
+        let canonical = PathBuf::from("/private/var/t/eval");
+        let raw = r#"{"path":"/private/var/t/eval/program.mi"}"#;
+
+        for roots in [
+            vec![nested.clone(), canonical.clone()],
+            vec![canonical.clone(), nested.clone()],
+        ] {
+            assert_eq!(
+                normalize_paths(raw, &roots),
+                r#"{"path":"./program.mi"}"#,
+                "the canonical root must be rewritten whichever order it arrives in"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What was red

`evals::test_replay_matches_the_committed_baseline` has failed every CI run and every nightly heap-guard run since 2026-09-03:

```
task b: bytesRead: 2330 -> 2290
task d: bytesRead: 1401 -> 1361
task e: bytesRead: 2030 -> 2022
```

## Root cause

`normalize_output` in `tests/evals/mod.rs` rewrites the working directory to `.` so the byte count is reproducible, and rewrites the canonical form too because macOS resolves temporary directories through `/private`. It pushed the roots in the order `[work_dir, canonical]` and replaced them in that order.

The shorter root is a substring of the longer one: `/var/folders/…` sits inside `/private/var/folders/…`. Replacing it first consumed the tail and left the literal `/private` standing — **8 platform-dependent bytes per path occurrence**. Tasks b and d carry 5 paths each (40 bytes), task e carries 1 (8 bytes). That is exactly the observed delta.

The committed baseline was blessed on macOS, so it recorded the padded counts. Linux CI computed the honest counts and failed. Nothing regressed in the agent loop.

## The fix

Replace the longest root first. `normalize_paths` is extracted so the ordering is directly testable, and a new test pins it in both argument orders.

## Verification

- RED: the new test failed with `"/private./program.mi"` before the fix.
- GREEN: after the fix macOS produces **2290 / 1361 / 2022** — byte-identical to what Linux CI computed. That equality is the point: the baseline is now platform-independent, so it is re-recorded.
- Local gate: `make format` clean, `make lint` exit 0, `make build` exit 0, suite **5660 passed / 0 failed / 231 ignored** (plus 220 unit and both runtime crates green), `make audit` exit 0.

https://claude.ai/code/session_01DejDxXyoaWCFhmpv8S5dda