### PR TITLE
Reject out-of-i32-range integer constant inside GPU kernel

### DIFF
--- a/src/type_checker/expressions/literals.rs
+++ b/src/type_checker/expressions/literals.rs
@@ -86,6 +86,7 @@ impl TypeChecker {
         lit: &Literal,
         expr_id: usize,
         span: Span,
+        context: &Context,
     ) {
         let Literal::Integer(int_lit) = lit else {
             return;
@@ -96,6 +97,28 @@ impl TypeChecker {
             return;
         }
         let value = int_lit.to_i128();
+
+        if context.in_gpu_function {
+            let max = if self.negated_int_literals.contains(&expr_id) {
+                i32::MAX as i128 + 1
+            } else {
+                i32::MAX as i128
+            };
+            if value > max {
+                self.report_error(
+                    DiagnosticCode::TarGpuValueOutOfRange,
+                    format!(
+                        "Integer literal '{}' is out of range for GPU 32-bit signed integer (i32 range is {} to {})",
+                        value,
+                        i32::MIN,
+                        i32::MAX
+                    ),
+                    span,
+                );
+            }
+            return;
+        }
+
         let max = if self.negated_int_literals.contains(&expr_id) {
             i64::MAX as i128 + 1
         } else {

--- a/src/type_checker/expressions/mod.rs
+++ b/src/type_checker/expressions/mod.rs
@@ -82,7 +82,7 @@ impl TypeChecker {
     ) -> Type {
         match kind {
             ExpressionKind::Literal(lit) => {
-                self.check_integer_literal_range(lit, expr_id, span);
+                self.check_integer_literal_range(lit, expr_id, span, context);
                 self.check_regex_literal(lit, span, context);
                 self.infer_literal(lit, context)
             }

--- a/tests/integration/gpu/launch.rs
+++ b/tests/integration/gpu/launch.rs
@@ -679,14 +679,22 @@ println(f'{h[0]} {h[1]} {h[2]}')
     assert_gpu_runs_with_output(source, "1 2 3");
 }
 
-// NOTE: the former `gpu_i64_divide_large_constant` / `gpu_i64_modulo_large_constant`
-// tests were removed. They asserted the old i64-constant-narrowing behaviour, where a
-// near-`i64::MAX` constant in a kernel was silently truncated into i32 range. GPU
-// integers are now i32 end-to-end (WebGPU/WGSL has no 64-bit integer type), so a
-// constant exceeding i32 range is genuinely unrepresentable in a kernel. In-range
-// integer div/mod stays covered by `gpu_i64_divide_roundtrips` / `gpu_i64_modulo_roundtrips`.
-// TODO: reject an out-of-i32-range integer constant inside a GPU kernel with a
-// clean compile-time error instead of the current shader-compile abort.
+/// Test that integer constants exceeding i32 range inside a GPU kernel
+/// produce a compile-time error.
+#[test]
+fn gpu_integer_constant_out_of_i32_range_rejected() {
+    let source = "
+use system.gpu
+use system.collections.array
+
+gpu let src = [1, 2, 3, 4]
+gpu var dst = [0, 0, 0, 0]
+
+gpu forall i in 0..4
+    dst[i] = src[i] + 3000000000
+";
+    assert_compiler_error(source, "3000000000");
+}
 
 /// Test negative dividend with division (i32 semantics: truncate toward zero).
 #[test]


### PR DESCRIPTION
Provides a clean compile-time error for out-of-i32-range integer constants in GPU kernels instead of a shader-compile abort.

---
*PR created automatically by Jules for task [6970872577158526968](https://jules.google.com/task/6970872577158526968) started by @slavikdev*