### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Compiler DoS via UTF-8 Boundary Slicing in Lexer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 **Vulnerability:** Integer overflow causing undersized allocations and heap buffer overflows (OOM DoS) in MiriList.
 **Learning:** `capacity * elem_size` without bounds checks wrappers can lead to extremely large inputs wrapping around, producing a small layout that receives too much data during memory copies or inserts.
 **Prevention:** Always use safe arithmetic like `checked_mul` (e.g., `capacity.checked_mul(elem_size)`) and return gracefully or use safe aborts if the required size overflows before calling `Layout::from_size_align` in manual memory management code. Ensure fallback paths (like returning an empty struct) are maintained if the checked math fails.
+
+## 2026-05-28 - [Compiler DoS via UTF-8 Boundary Slicing in Lexer]
+**Vulnerability:** Slicing source strings with fixed 1-byte ranges (`&src[cursor..cursor + 1]`) in lexer lookahead routines panics when `cursor` points to a multi-byte UTF-8 character.
+**Learning:** `&str` slicing in Rust requires exact UTF-8 character boundaries. Lookahead logic operating on raw byte offsets must not slice `&str` directly without verifying character boundaries.
+**Prevention:** Inspect `src.as_bytes()` or use byte matching instead of `&str` slicing for single-ASCII-character lookahead checks.

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -399,13 +399,15 @@ impl<'source> Lexer<'source> {
         let src = self.inner.source();
         let lookahead_cursor = self.inner.span().end;
 
+        // Security invariant: inspect single bytes instead of slicing `&src[x..x+1]`,
+        // which panics when `lookahead_cursor` lands on a multi-byte UTF-8 character (Compiler DoS).
         if lookahead_cursor < src.len() {
-            let ch = &src[lookahead_cursor..lookahead_cursor + 1];
-            if ch == "." {
+            let byte = src.as_bytes()[lookahead_cursor];
+            if byte == b'.' {
                 self.split_range(lookahead_cursor);
                 return Ok(());
             }
-            if ch.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+            if (byte as char).is_ascii_alphabetic() {
                 self.split_int_dot();
                 return Ok(());
             }
@@ -425,7 +427,8 @@ impl<'source> Lexer<'source> {
         let range_end = lookahead_cursor + 1;
 
         let int_span = Span::new(self.inner.span().start, range_start);
-        if range_end < src.len() && &src[range_end..range_end + 1] == "=" {
+        // Security invariant: inspect byte array to avoid slicing across non-ASCII UTF-8 boundaries.
+        if range_end < src.len() && src.as_bytes()[range_end] == b'=' {
             self.pending_tokens_stack
                 .push((Token::RangeInclusive, Span::new(range_start, range_end + 1)));
             self.inner.bump(2);

--- a/tests/lexer/edge_cases.rs
+++ b/tests/lexer/edge_cases.rs
@@ -208,3 +208,11 @@ fn test_null_byte_in_string() {
     lexer_token_test("\"\\0\"", vec![Token::String]);
     lexer_token_test("\"raw null \0 byte\"", vec![Token::String]);
 }
+
+#[test]
+fn test_multibyte_utf8_after_number_does_not_panic() {
+    // Non-ASCII UTF-8 character immediately following a dot or range operator
+    // must not slice across UTF-8 char boundaries and panic the lexer.
+    let _ = miri::lexer::Lexer::new("42.é").collect::<Vec<_>>();
+    let _ = miri::lexer::Lexer::new("0..=ä").collect::<Vec<_>>();
+}


### PR DESCRIPTION
### 🚨 Severity
CRITICAL (Compiler Denial of Service)

### 💡 Vulnerability
In `src/lexer/mod.rs`, single-character lookahead routines (`lex_float_or_range` and `split_range`) sliced source strings using fixed 1-byte ranges (`&src[lookahead_cursor..lookahead_cursor + 1]` and `&src[range_end..range_end + 1]`). When processing non-ASCII UTF-8 input immediately following a number or dot (such as multi-byte characters like `é` or `ä`), string slicing across non-char boundaries caused the Rust runtime to panic (`byte index X is not a char boundary`), crashing the compiler process abruptly.

### 🎯 Impact
An attacker supplying untrusted `.mi` source code containing non-ASCII UTF-8 characters following numeric or range tokens could trigger a compiler process crash (Compiler DoS).

### 🔧 Fix
Replaced `&str` slicing with safe byte array checks on `src.as_bytes()`. Inspecting byte values directly avoids `&str` slice allocations across multi-byte character boundaries, eliminating the panic condition while preserving identical lexing behavior for valid ASCII tokens.

### ✅ Verification
- **Regression Test:** Added `test_multibyte_utf8_after_number_does_not_panic` in `tests/lexer/edge_cases.rs` confirming that non-ASCII source characters following numbers/dots fail gracefully without panicking.
- **Gate Output:**
  - `make format`: Clean (empty diff).
  - `make lint` (`cargo clippy --lib -- -D warnings`): Clean (0 warnings).
  - Lexer suite (`cargo test --test mod lexer`): **245 passed, 0 failed**.
- Updated `.jules/sentinel.md` with learnings on safe lookahead character checks.

---
*PR created automatically by Jules for task [15106701796750806773](https://jules.google.com/task/15106701796750806773) started by @slavikdev*