### PR TITLE
🛡️ Sentinel: [HIGH] Fix compiler DoS panic on non-ASCII input in Lexer::lex_float_or_range

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 **Vulnerability:** Integer overflow causing undersized allocations and heap buffer overflows (OOM DoS) in MiriList.
 **Learning:** `capacity * elem_size` without bounds checks wrappers can lead to extremely large inputs wrapping around, producing a small layout that receives too much data during memory copies or inserts.
 **Prevention:** Always use safe arithmetic like `checked_mul` (e.g., `capacity.checked_mul(elem_size)`) and return gracefully or use safe aborts if the required size overflows before calling `Layout::from_size_align` in manual memory management code. Ensure fallback paths (like returning an empty struct) are maintained if the checked math fails.
+
+## 2025-05-18 - [Compiler DoS via UTF-8 Boundary Panic on Lookahead Slicing]
+**Vulnerability:** `Lexer::lex_float_or_range` sliced source strings using fixed 1-byte ranges (`&src[lookahead_cursor..lookahead_cursor + 1]`), panicking if `lookahead_cursor` landed on a multi-byte UTF-8 character boundary (e.g. `1.日本語`).
+**Learning:** Slicing Rust string references (`&str`) by byte offsets without verifying character boundaries panics when encountering non-ASCII UTF-8 sequences. Lookahead logic operating on single-byte characters/tokens must operate on raw byte slices (`src.as_bytes()`) or character iterators.
+**Prevention:** Inspect lookahead tokens using `src.as_bytes()[cursor]` directly or byte slice methods instead of string slice ranges (`&src[x..x+1]`).

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -400,12 +400,15 @@ impl<'source> Lexer<'source> {
         let lookahead_cursor = self.inner.span().end;
 
         if lookahead_cursor < src.len() {
-            let ch = &src[lookahead_cursor..lookahead_cursor + 1];
-            if ch == "." {
+            // Security Invariant: Check lookahead bytes directly on src.as_bytes()
+            // rather than string slicing (&src[lookahead_cursor..lookahead_cursor + 1])
+            // to prevent UTF-8 boundary panics (compiler DoS) on non-ASCII lookahead input.
+            let next_byte = src.as_bytes()[lookahead_cursor];
+            if next_byte == b'.' {
                 self.split_range(lookahead_cursor);
                 return Ok(());
             }
-            if ch.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+            if next_byte.is_ascii_alphabetic() {
                 self.split_int_dot();
                 return Ok(());
             }

--- a/tests/lexer/number.rs
+++ b/tests/lexer/number.rs
@@ -196,6 +196,14 @@ fn test_invalid_hex() {
 }
 
 #[test]
+fn test_float_followed_by_non_ascii() {
+    // Non-ASCII characters following `1.` do not match ASCII identifier rules,
+    // so `1.` is split into Int and Dot, and the non-ASCII char is reported as InvalidToken
+    // without panicking on UTF-8 boundaries.
+    lexer_error_test("1.日本語", &SyntaxErrorKind::InvalidToken);
+}
+
+#[test]
 fn test_number_followed_by_dot_method_call() {
     // This is a critical test to ensure `1.to_string()` is not confused with a float.
     // The `FloatOrRange` logic should correctly see the `t` and treat `1.` as member call of an integer,


### PR DESCRIPTION
## 🛡️ Sentinel: [HIGH] Fix compiler DoS panic on non-ASCII input in `Lexer::lex_float_or_range`

### 🚨 Severity
**HIGH** — Compiler Denial of Service (Reachable panic on untrusted input).

### 💡 Vulnerability
When lexing numeric literals followed by a dot (e.g. `1.日本語`), `Lexer::lex_float_or_range` in `src/lexer/mod.rs` performed fixed 1-byte string slice indexing (`&src[lookahead_cursor..lookahead_cursor + 1]`) to inspect the lookahead character. When non-ASCII UTF-8 characters immediately followed a numeric dot, this slicing landed in the middle of a multi-byte UTF-8 character boundary, causing an immediate panic in the compiler process.

### 🎯 Impact
An attacker providing untrusted `.mi` source files containing non-ASCII characters directly following a numeric dot could crash the Miri compiler process with a thread panic (`end byte index X is not a char boundary`).

### 🔧 Fix
Replaced raw string slice range indexing `&src[lookahead_cursor..lookahead_cursor + 1]` in `lex_float_or_range` with safe byte-level inspection `src.as_bytes()[lookahead_cursor]` and `next_byte.is_ascii_alphabetic()`. Added a security invariant comment explaining the protection against UTF-8 boundary panics.

### ✅ Verification
- Added a regression unit test `test_float_followed_by_non_ascii` in `tests/lexer/number.rs`. Confirmed that it panicked on un-fixed code and passes cleanly returning `SyntaxErrorKind::InvalidToken` with the fix.
- Full verification gate passed cleanly:
  - `make format`: Clean empty diff.
  - `make lint`: Clean.
  - `make build`: Clean.
  - `cargo test --test mod -- lexer`: 245 tests passed (0 failed).

*Updated `.jules/sentinel.md` with critical learning on safe lookahead slicing.*

---
*PR created automatically by Jules for task [4162314733368732525](https://jules.google.com/task/4162314733368732525) started by @slavikdev*