### PR TITLE
🔒 Fix unvalidated linker path configuration via environment variables

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2782,14 +2782,43 @@ fn native_binary_path(bundle_dir: &Path) -> PathBuf {
     bundle_dir.join(name)
 }
 
+/// Resolves a candidate binary string (from `MIRI_CC` or `CC`) safely.
+/// Returns an absolute path if provided, or resolves a bare command name via system `PATH`.
+/// Relative paths with directory separators are rejected to prevent CWD hijacking.
+fn resolve_binary_path(val: &str) -> Result<PathBuf, CompilerError> {
+    let path = PathBuf::from(val);
+    if path.is_absolute() {
+        return Ok(path);
+    }
+
+    if path.components().count() == 1 {
+        if let Ok(path_env) = std::env::var("PATH") {
+            for dir in std::env::split_paths(&path_env) {
+                let candidate = dir.join(&path);
+                if candidate.is_file() {
+                    return Ok(candidate);
+                }
+            }
+        }
+        // If not found in PATH, return the path object as-is so command execution
+        // fails gracefully with a standard command lookup error instead of hard erroring here.
+        return Ok(path);
+    }
+
+    Err(CompilerError::Codegen(format!(
+        "Invalid linker path '{}': relative paths containing directory separators are not allowed",
+        val
+    )))
+}
+
 /// Resolve the path to the linker (cc) using absolute paths or environment variables.
 /// This prevents unqualified command execution vulnerabilities.
 fn resolve_linker() -> Result<PathBuf, CompilerError> {
     if let Ok(cc) = std::env::var("MIRI_CC") {
-        return Ok(PathBuf::from(cc));
+        return resolve_binary_path(&cc);
     }
     if let Ok(cc) = std::env::var("CC") {
-        return Ok(PathBuf::from(cc));
+        return resolve_binary_path(&cc);
     }
 
     // Default to common absolute paths for 'cc'

--- a/tests/integration/linker/resolution.rs
+++ b/tests/integration/linker/resolution.rs
@@ -19,6 +19,40 @@ fn test_linker_resolution_miri_cc() {
     result.unwrap();
 }
 
+/// Relative linker paths containing directory separators must be rejected
+/// to prevent CWD/relative path hijacking vulnerabilities.
+#[test]
+fn test_linker_resolution_rejects_relative_path_with_separators() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    let relative_path = "./bogus_relative_cc";
+
+    env::remove_var("CC");
+    env::set_var("MIRI_CC", relative_path);
+
+    let pipeline = miri::pipeline::Pipeline::new();
+    let opts = miri::pipeline::BuildOptions {
+        out_path: Some(std::path::PathBuf::from("/tmp/miri_linker_test_output")),
+        ..Default::default()
+    };
+
+    let result = pipeline.build("0", &opts);
+    env::remove_var("MIRI_CC");
+
+    match result {
+        Err(miri::error::compiler::CompilerError::Codegen(msg)) => {
+            assert!(
+                msg.contains("relative paths containing directory separators are not allowed"),
+                "Expected error message for relative linker path rejection, got: {}",
+                msg
+            );
+        }
+        other => panic!(
+            "Expected Codegen error rejecting relative linker path, got: {:?}",
+            other
+        ),
+    }
+}
+
 /// When `MIRI_CC` is absent, the `CC` environment variable is used as the
 /// linker.  A bogus path must produce the same linker error.
 #[test]


### PR DESCRIPTION
🎯 **What**: Fixed unvalidated linker path resolution from `MIRI_CC` and `CC` environment variables.

⚠️ **Risk**: Unvalidated relative linker paths could lead to command injection or binary hijacking from the current working directory.

🛡️ **Solution**: Require `MIRI_CC` and `CC` paths to be absolute or bare names resolved securely via system `PATH`, rejecting relative paths with separators.

---
*PR created automatically by Jules for task [2126071817030125826](https://jules.google.com/task/2126071817030125826) started by @slavikdev*