### PR TITLE
🔎 Scout: Fix sub-word list element stride in List constructor lowering and runtime FFI

### DIFF
--- a/src/mir/lowering/constructors.rs
+++ b/src/mir/lowering/constructors.rs
@@ -515,10 +515,43 @@ pub(crate) const COLLECTION_CTORS: &[(BuiltinCollectionKind, CollectionCtorFn)] 
     (BuiltinCollectionKind::Array, lower_array_constructor),
 ];
 
+/// Extracts the element size in bytes for a `List<T>` from its type definition.
+fn extract_list_elem_size(ctx: &LoweringContext, list_ty: &Type) -> i64 {
+    let elem_kind = match &list_ty.kind {
+        TypeKind::List(inner_expr) => {
+            if let Some(ty) = ctx.type_checker.get_type(inner_expr.id) {
+                Some(ty.kind.clone())
+            } else if let Some(inferred) = infer_type_from_generic_arg(inner_expr, ctx) {
+                Some(inferred.kind)
+            } else {
+                None
+            }
+        }
+        TypeKind::Custom(name, Some(args))
+            if BuiltinCollectionKind::from_name(name) == Some(BuiltinCollectionKind::List)
+                && !args.is_empty() =>
+        {
+            if let Some(ty) = ctx.type_checker.get_type(args[0].id) {
+                Some(ty.kind.clone())
+            } else if let Some(inferred) = infer_type_from_generic_arg(&args[0], ctx) {
+                Some(inferred.kind)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    if let Some(ref kind) = elem_kind {
+        compute_elem_size_from_type(kind)
+    } else {
+        8
+    }
+}
+
 /// Lowers a `List(args)` constructor call.
 ///
 /// Two forms are supported:
-/// - `List()` — allocates an empty list with a default element stride of 8 bytes.
+/// - `List()` — allocates an empty list with the element stride determined by `T`.
 /// - `List([...])` — converts an array literal into a list, choosing the
 ///   managed-array variant when elements are heap-allocated so RC is correct.
 pub(crate) fn lower_list_constructor(
@@ -543,26 +576,20 @@ pub(crate) fn lower_list_constructor(
     };
 
     let target_bb = ctx.new_basic_block();
+    let elem_size = extract_list_elem_size(ctx, &list_ty);
 
     if args.len() == 1 {
         let array_op = lower_expression(ctx, &args[0], None)?;
 
         // Track the temp array local so we can emit StorageDead after the call.
-        let temp_array_local = match &array_op {
-            Operand::Copy(p) | Operand::Move(p) => Some(p.clone()),
-            _ => None,
-        };
-
-        // Determine array length, element size, and whether elements are
+        // Determine array length and whether elements are
         // RC-managed (Option, List, Array, etc.) from the array literal.
         let mut len_val = 0i64;
-        let mut elem_size = 8i64;
         let mut elems_are_managed = false;
         if let ExpressionKind::Array(elements, _) = &args[0].node {
             len_val = elements.len() as i64;
             if !elements.is_empty() {
                 if let Some(ty) = ctx.type_checker.get_type(elements[0].id) {
-                    elem_size = compute_elem_size_from_type(&ty.kind);
                     elems_are_managed = ctx.is_perceus_managed(&ty.kind);
                 }
             }
@@ -598,6 +625,11 @@ pub(crate) fn lower_list_constructor(
             literal: crate::ast::literal::Literal::Identifier(rt_fn_name.to_string()),
         }));
 
+        let temp_array_local = match &array_op {
+            Operand::Copy(p) | Operand::Move(p) => Some(p.clone()),
+            _ => None,
+        };
+
         ctx.set_terminator(Terminator::new(
             TerminatorKind::Call {
                 func: func_op,
@@ -629,13 +661,12 @@ pub(crate) fn lower_list_constructor(
         ctx.set_current_block(final_bb);
         return Ok(result_op);
     } else {
-        // List() with no arguments: allocate an empty list.
-        // Use a default element stride of 8 bytes (pointer-sized).
+        // List() with no arguments: allocate an empty list with element stride elem_size.
         let size_op = Operand::Constant(Box::new(Constant {
             span: *span,
             ty: Type::new(TypeKind::Int, *span),
             literal: crate::ast::literal::Literal::Integer(
-                crate::ast::literal::IntegerLiteral::I64(8),
+                crate::ast::literal::IntegerLiteral::I64(elem_size),
             ),
         }));
         let func_op = Operand::Constant(Box::new(Constant {

--- a/src/runtime/core/src/list.rs
+++ b/src/runtime/core/src/list.rs
@@ -328,23 +328,30 @@ pub mod ffi {
     pub unsafe extern "C" fn miri_rt_list_new_from_raw(
         array: *mut crate::array::MiriArray,
         _len: usize,
-        _elem_size: usize,
+        elem_size: usize,
     ) -> *mut MiriList {
+        let arr_elem_size = if !array.is_null() {
+            (*array).elem_size()
+        } else {
+            8
+        };
+        let target_elem_size = if elem_size > 0 {
+            elem_size
+        } else {
+            arr_elem_size
+        };
         if array.is_null() {
-            // Fallback: use _elem_size if provided, otherwise default to 8
-            let es = if _elem_size > 0 { _elem_size } else { 8 };
-            return miri_rt_list_new(es);
+            return miri_rt_list_new(target_elem_size);
         }
         let arr = &*array;
         let data = arr.data_ptr();
         let len = arr.len();
-        let elem_size = arr.elem_size();
         if data.is_null() || len == 0 {
-            return miri_rt_list_new(elem_size);
+            return miri_rt_list_new(target_elem_size);
         }
-        let list = miri_rt_list_new(elem_size);
+        let list = miri_rt_list_new(target_elem_size);
         for i in 0..len {
-            (*list).push(data.add(i * elem_size));
+            (*list).push(data.add(i * arr_elem_size));
         }
         list
     }

--- a/tests/integration/primitive_types/unsigned_projected_reads.rs
+++ b/tests/integration/primitive_types/unsigned_projected_reads.rs
@@ -81,13 +81,6 @@ fn main()
 }
 
 #[test]
-#[ignore = "Sub-word list elements past index 0 read back as zero: the element \
-stride the list is built at does not match the stride its reads address it by. \
-The source array literal inside List<u8>([...]) is typed as a bare Array with no \
-element type, so it is built at the pointer width while every read of the list \
-steps by one byte, and each element after the first lands between slots. Affects \
-every element narrower than a word (u8/i8/u16/i16/i32/u32/f32), not just \
-unsigned ones. Index 0 is correct because both strides start there."]
 fn test_u8_list_literal_element_reads_back_whole() {
     assert_runs_with_output(
         r#"
@@ -166,9 +159,6 @@ fn main()
 }
 
 #[test]
-#[ignore = "Sub-word list elements past index 0 read back as zero — see \
-test_u8_list_literal_element_reads_back_whole for the stride mismatch. Recorded \
-at i32 as well to show the defect is about element width, not signedness."]
 fn test_i32_list_second_element_reads_back_whole() {
     assert_runs_with_output(
         r#"
@@ -185,9 +175,6 @@ fn main()
 }
 
 #[test]
-#[ignore = "Sub-word list elements past index 0 read back as zero — see \
-test_u8_list_literal_element_reads_back_whole. Pushing rather than building from \
-a literal reaches the same mismatch."]
 fn test_u8_list_second_pushed_element_reads_back_whole() {
     assert_runs_with_output(
         r#"


### PR DESCRIPTION
Fixes an issue where sub-word list elements (u8, i32, etc.) past index 0 read back as zero due to an element stride mismatch between MIR constructor lowering and miri_rt_list_new_from_raw FFI.

1. Compiler Lowering (src/mir/lowering/constructors.rs): Added extract_list_elem_size to compute element stride from list_ty rather than defaulting to 8 bytes.
2. Runtime FFI (src/runtime/core/src/list.rs): Updated miri_rt_list_new_from_raw to respect target_elem_size (3rd parameter) while stepping through source array elements by arr.elem_size().
3. Un-ignored test_u8_list_literal_element_reads_back_whole, test_i32_list_second_element_reads_back_whole, and test_u8_list_second_pushed_element_reads_back_whole in tests/integration/primitive_types/unsigned_projected_reads.rs.

---
*PR created automatically by Jules for task [7252026644656121388](https://jules.google.com/task/7252026644656121388) started by @slavikdev*