### PR TITLE
🧹 Reduce duplicate diagnostic construction with JsonDiagnostic::error

### DIFF
--- a/src/cli/determinism.rs
+++ b/src/cli/determinism.rs
@@ -330,22 +330,7 @@ fn build_failure_envelope(
 /// Envelope for a failure of this command's own machinery rather than of the
 /// build it was asked to check.
 fn command_failure_envelope(message: &str, elapsed_ms: u64) -> DiagnosticsEnvelope {
-    let diagnostic = JsonDiagnostic {
-        severity: "error".to_string(),
-        code: None,
-        message: message.to_string(),
-        path: None,
-        line: None,
-        column: None,
-        length: None,
-        expected: None,
-        actual: None,
-        help: None,
-        fix_safety: None,
-        repair: None,
-        related: vec![],
-        preexisting: None,
-    };
+    let diagnostic = JsonDiagnostic::error(message, None);
     DiagnosticsEnvelope::new(JsonCommand::Determinism, false, vec![diagnostic])
         .with_exit_code(1)
         .with_duration_ms(elapsed_ms)

--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -341,6 +341,29 @@ pub struct JsonDiagnostic {
     pub preexisting: Option<bool>,
 }
 
+impl JsonDiagnostic {
+    /// Construct a minimal error diagnostic with severity "error", default None/empty fields,
+    /// and optional diagnostic code.
+    pub fn error(message: impl Into<String>, code: Option<String>) -> Self {
+        Self {
+            severity: "error".to_string(),
+            code,
+            message: message.into(),
+            path: None,
+            line: None,
+            column: None,
+            length: None,
+            expected: None,
+            actual: None,
+            help: None,
+            fix_safety: None,
+            repair: None,
+            related: vec![],
+            preexisting: None,
+        }
+    }
+}
+
 /// A repair suggestion (reserved for Task 4).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,22 +343,7 @@ fn report_run(
 
 /// Create an error diagnostic from a code and message.
 fn error_diagnostic(code: String, message: String) -> JsonDiagnostic {
-    JsonDiagnostic {
-        severity: "error".to_string(),
-        code: Some(code),
-        message,
-        path: None,
-        line: None,
-        column: None,
-        length: None,
-        expected: None,
-        actual: None,
-        help: None,
-        fix_safety: None,
-        repair: None,
-        related: vec![],
-        preexisting: None,
-    }
+    JsonDiagnostic::error(message, Some(code))
 }
 
 /// The diagnostic a runtime trap is reported as.


### PR DESCRIPTION
🎯 **What:** Introduced a `JsonDiagnostic::error` constructor on `JsonDiagnostic` in `src/diagnostics/json.rs` and refactored `command_failure_envelope` in `src/cli/determinism.rs` and `error_diagnostic` in `src/main.rs` to use it.

💡 **Why:** Both call sites manually constructed `JsonDiagnostic` structs with many explicit `None` / empty fields. Reusing `JsonDiagnostic::error` eliminates boilerplate and reduces duplicate diagnostic generation logic across CLI and main execution modules.

✅ **Verification:** Verified compilation via `cargo check`, ran unit tests via `cargo test --lib`, ran linter checks via `cargo clippy --lib -- -D warnings`, and checked formatting via `cargo fmt --check`.

✨ **Result:** Cleaner, more maintainable code with reduced duplication for error diagnostic creation.

---
*PR created automatically by Jules for task [12341628368475859392](https://jules.google.com/task/12341628368475859392) started by @slavikdev*