### PR TITLE
⚡ Bolt: Eliminate redundant string allocations when resolving trait default methods

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1320,16 +1320,16 @@ impl Pipeline {
         else {
             return Vec::new();
         };
-        let mut wanted: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut pending: Vec<String> = def.traits.clone();
+        let mut wanted: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut pending: Vec<&str> = def.traits.iter().map(String::as_str).collect();
         while let Some(trait_name) = pending.pop() {
-            if !wanted.insert(trait_name.clone()) {
+            if !wanted.insert(trait_name) {
                 continue;
             }
             if let Some(TypeDefinition::Trait(trait_def)) =
-                result.type_checker.type_definitions().get(&trait_name)
+                result.type_checker.type_definitions().get(trait_name)
             {
-                pending.extend(trait_def.parent_traits.iter().cloned());
+                pending.extend(trait_def.parent_traits.iter().map(String::as_str));
             }
         }
 


### PR DESCRIPTION
⚡ Bolt: Eliminate redundant string allocations when resolving trait default methods

### 💡 What
Refactored `Pipeline::trait_default_methods_for_class` in `src/pipeline.rs` to use `HashSet<&str>` and `Vec<&str>` borrowing `&str` directly from `TypeDefinition::Class` and `TypeDefinition::Trait` definitions.

### 🎯 Why
Previously, resolving default methods for a class cloned all trait names into `pending: Vec<String>`, cloned each trait name on insertion into `wanted: HashSet<String>`, and cloned parent trait names when extending `pending`. This introduced unnecessary heap allocations and string cloning on every iteration during compilation.

### 📊 Measured Improvement
Eliminated 100% of heap string allocations inside the trait traversal loop of `trait_default_methods_for_class`. All lookup operations now borrow references with zero allocation overhead.

---
*PR created automatically by Jules for task [9827635699792314933](https://jules.google.com/task/9827635699792314933) started by @slavikdev*