### PR TITLE
🔒 Fix thread-unsafe environment variable modifications in runtime

### DIFF
--- a/src/runtime/core/src/os.rs
+++ b/src/runtime/core/src/os.rs
@@ -15,9 +15,13 @@
 //! - 3 = other OS error
 
 use std::cell::RefCell;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use crate::string::{into_raw_ptr, MiriString};
+
+/// Global lock to synchronize environment variable access (`std::env::var`, `std::env::set_var`)
+/// across threads to prevent data races and UB/segfaults in C/POSIX env manipulation.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 thread_local! {
     /// Thread-local status code for the last environment operation.
@@ -78,6 +82,7 @@ pub mod ffi {
 
         let name_str = (*name).as_str();
         set_env_status(0, String::new());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         if std::env::var(name_str).is_ok() {
             1
         } else {
@@ -105,6 +110,7 @@ pub mod ffi {
 
         let name_str = (*name).as_str();
         set_env_status(0, String::new());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let value = std::env::var(name_str).unwrap_or_default();
         into_raw_ptr(MiriString::from_str(&value))
     }
@@ -150,11 +156,15 @@ pub mod ffi {
             return 0;
         }
 
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
         // Check if the variable was already set
         let was_set = std::env::var(name_str).is_ok();
 
         // Set the environment variable (this only affects this process and children)
-        std::env::set_var(name_str, value_str);
+        unsafe {
+            std::env::set_var(name_str, value_str);
+        }
 
         set_env_status(0, String::new());
         if was_set {

--- a/src/runtime/core/tests/os_tests.rs
+++ b/src/runtime/core/tests/os_tests.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Viacheslav Shynkarenko
+
+//! Unit tests for OS environment operations and thread safety.
+
+use miri_runtime_core::{
+    miri_rt_env_get, miri_rt_env_has, miri_rt_env_set, miri_rt_string_free, miri_rt_string_from_raw,
+};
+use std::thread;
+
+#[test]
+fn test_concurrent_env_operations() {
+    let num_threads = 10;
+    let iterations = 100;
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|t| {
+            thread::spawn(move || {
+                let var_name = format!("MIRI_CONCURRENT_TEST_VAR_{}", t % 3);
+                let name_ptr =
+                    unsafe { miri_rt_string_from_raw(var_name.as_ptr(), var_name.len()) };
+
+                for i in 0..iterations {
+                    let val_str = format!("val_{}_{}", t, i);
+                    let val_ptr =
+                        unsafe { miri_rt_string_from_raw(val_str.as_ptr(), val_str.len()) };
+
+                    unsafe {
+                        let _ = miri_rt_env_set(name_ptr, val_ptr);
+                        let _ = miri_rt_env_has(name_ptr);
+                        let res_ptr = miri_rt_env_get(name_ptr);
+                        miri_rt_string_free(res_ptr);
+                        miri_rt_string_free(val_ptr);
+                    }
+                }
+
+                unsafe {
+                    miri_rt_string_free(name_ptr);
+                }
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle
+            .join()
+            .expect("Thread panicked during concurrent env test");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Fixed thread-unsafe process environment variable modifications in `src/runtime/core/src/os.rs` by introducing process-global synchronization via `ENV_LOCK: Mutex<()>`.

⚠️ **Risk:** Without synchronization, multi-threaded Miri runtime operations or concurrent user scripts executing `Env.set()`, `Env.get()`, or `Env.has()` could trigger data races on `environ`, causing memory corruption, undefined behavior, or process segmentation faults.

🛡️ **Solution:** Synchronized all environment access in `src/runtime/core/src/os.rs` (`miri_rt_env_has`, `miri_rt_env_get`, and `miri_rt_env_set`) using `ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())` and marked `std::env::set_var` within an explicit `unsafe` block. Added multi-threaded concurrent tests in `src/runtime/core/tests/os_tests.rs` to verify thread safety.

---
*PR created automatically by Jules for task [8045877859688494119](https://jules.google.com/task/8045877859688494119) started by @slavikdev*