### PR TITLE
🧹 Sanitize comments and docstrings in src/diagnostics/

### DIFF
--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -399,7 +399,7 @@ impl JsonDiagnostic {
     }
 }
 
-/// A repair suggestion (reserved for Task 4).
+/// A repair suggestion attached to a diagnostic.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct JsonRepair {


### PR DESCRIPTION
🎯 **What**
Sanitized doc comments in `src/diagnostics/` to remove internal planning artifacts (specifically removing `(reserved for Task 4)` in `src/diagnostics/json.rs` and replacing it with clean, descriptive documentation).

💡 **Why**
Ensures all documentation and docstrings are professional, consistent, clear, and sanitized of internal planning/roadmap references in accordance with codebase cleanliness guidelines.

✅ **Verification**
- Verified with `git diff` that only doc comments were modified and no functional code/logic was changed.
- Verified with `cargo fmt --check` and `cargo test --lib` (285 passing tests).
- Code review approved with #Correct#.

✨ **Result**
The `src/diagnostics/` subsystem is fully sanitized of internal planning references, maintaining high documentation quality standards.

---
*PR created automatically by Jules for task [16431176958044665012](https://jules.google.com/task/16431176958044665012) started by @slavikdev*